### PR TITLE
More improvements (see description)

### DIFF
--- a/Avalonia.Ribbon.Sample/Views/MainWindow.xaml
+++ b/Avalonia.Ribbon.Sample/Views/MainWindow.xaml
@@ -1,77 +1,79 @@
-﻿<Window
+﻿<local:RibbonWindow
     x:Class="Avalonia.Ribbon.Samples.Views.MainWindow"
     xmlns="https://github.com/avaloniaui"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:vm="clr-namespace:Avalonia.Ribbon.Samples.ViewModels;assembly=Avalonia.Ribbon.Sample"
+    xmlns:local="clr-namespace:Avalonia.Controls.Ribbon;assembly=Avalonia.Ribbon"
     Title="Avalonia Ribbon"
     d:DesignHeight="450"
     d:DesignWidth="800"
-    HasSystemDecorations="False"
+    HasSystemDecorations="false"
     Icon="/Assets/avalonia-logo.ico"
     mc:Ignorable="d">
 
-    <Design.DataContext>
-        <vm:MainWindowViewModel />
-    </Design.DataContext>
-
-    <RibbonWindow>
-        <RibbonControl>
-            <RibbonControl.MenuItems>
-                <MenuItem Header="Item 1">
-                  <MenuItem Header="SubItem 1"/>
-                  <MenuItem Header="SubItem 2"/>
-                </MenuItem>
-              <MenuItem Header="Item 2">
-                <MenuItem Header="SubItem 1"/>
-                <MenuItem Header="SubItem 2"/>
-                <MenuItem Header="SubItem 3"/>
-              </MenuItem>
-            </RibbonControl.MenuItems>
-            <RibbonControl.MenuPlacesItems>
-              <ListBoxItem Content="Place 1"/>
-              <ListBoxItem Content="Place 2"/>
-              <ListBoxItem Content="Place 3"/>
-            </RibbonControl.MenuPlacesItems>
-            <RibbonTab Header="RibbonTab 1">
-                <StackPanel Orientation="Horizontal">
-                    <RibbonTabGroup Text="Un premier groupe">
-                        <StackPanel Orientation="Horizontal">
-                            <RibbonButton IconPath="/Assets/RibbonIcons/settings.png" Text="Test3" />
-                            <RibbonButton IconPath="/Assets/RibbonIcons/corner.png" Text="Test4" />
-                            <RibbonButton IconPath="/Assets/RibbonIcons/chevron.png" Text="Test5" />
-                            <RibbonButton IconPath="/Assets/RibbonIcons/settings.png" Text="Test6" />
-                        </StackPanel>
-                    </RibbonTabGroup>
-                    <RibbonTabGroup Command="{Binding OnClickCommand}" Text="Paragraphe">
-                        <StackPanel Orientation="Horizontal">
-                            <StackPanel Orientation="Vertical">
-                                <!--  Maximum 3 buttons per vertical stackpanel  -->
-                                <RibbonLinearButton
-                                    Command="{Binding OnClickCommand}"
-                                    IconPath="/Assets/RibbonIcons/corner.png"
-                                    Text="Reproduire la mise en forme" />
-                                <RibbonLinearButton IconPath="/Assets/RibbonIcons/settings.png" Text="Test8" />
-                                <RibbonLinearButton IconPath="/Assets/RibbonIcons/settings.png" Text="Test9" />
-                            </StackPanel>
-                            <RibbonComboButton IconPath="/Assets/RibbonIcons/settings.png" Text="Coller">
-                                <ComboBoxItem>ksdlfml</ComboBoxItem>
-                                <ComboBoxItem>ksdnvbl</ComboBoxItem>
-                            </RibbonComboButton>
-                            <StackPanel>
-                                <RibbonSmallButtonHGroup>
-                                    <RibbonSmallButton IconPath="/Assets/RibbonIcons/settings.png" ToolTip.Tip="A small tooltip" />
-                                    <RibbonSmallButton IconPath="/Assets/RibbonIcons/settings.png" />
-                                    <RibbonSmallButton IconPath="/Assets/RibbonIcons/settings.png" />
-                                </RibbonSmallButtonHGroup>
-                            </StackPanel>
-                        </StackPanel>
-                    </RibbonTabGroup>
-                </StackPanel>
-            </RibbonTab>
-            <RibbonTab Header="RibbonTab 2">qsdfqsdf</RibbonTab>
-        </RibbonControl>
-    </RibbonWindow>
-
-</Window>
+  <Design.DataContext>
+    <vm:MainWindowViewModel />
+  </Design.DataContext>
+  <DockPanel>
+    <RibbonControl DockPanel.Dock="Top">
+      <RibbonControl.MenuItems>
+        <MenuItem Header="Item 1">
+          <MenuItem Header="SubItem 1"/>
+          <MenuItem Header="SubItem 2"/>
+        </MenuItem>
+        <MenuItem Header="Item 2">
+          <MenuItem Header="SubItem 1"/>
+          <MenuItem Header="SubItem 2"/>
+          <MenuItem Header="SubItem 3"/>
+        </MenuItem>
+      </RibbonControl.MenuItems>
+      <RibbonControl.MenuPlacesItems>
+        <ListBoxItem Content="Place 1"/>
+        <ListBoxItem Content="Place 2"/>
+        <ListBoxItem Content="Place 3"/>
+      </RibbonControl.MenuPlacesItems>
+      <RibbonTab Header="RibbonTab 1">
+        <StackPanel Orientation="Horizontal">
+          <RibbonTabGroup Text="Un premier groupe">
+            <StackPanel Orientation="Horizontal">
+              <RibbonButton IconPath="/Assets/RibbonIcons/settings.png" Text="Test3" />
+              <RibbonButton IconPath="/Assets/RibbonIcons/corner.png" Text="Test4" />
+              <RibbonButton IconPath="/Assets/RibbonIcons/chevron.png" Text="Test5" />
+              <RibbonButton IconPath="/Assets/RibbonIcons/settings.png" Text="Test6" />
+            </StackPanel>
+          </RibbonTabGroup>
+          <RibbonTabGroup Command="{Binding OnClickCommand}" Text="Paragraphe">
+            <StackPanel Orientation="Horizontal">
+              <StackPanel Orientation="Vertical">
+                <!--  Maximum 3 buttons per vertical stackpanel  -->
+                <RibbonLinearButton
+                    Command="{Binding OnClickCommand}"
+                    IconPath="/Assets/RibbonIcons/corner.png"
+                    Text="Reproduire la mise en forme" />
+                <RibbonLinearButton IconPath="/Assets/RibbonIcons/settings.png" Text="Test8" />
+                <RibbonLinearButton IconPath="/Assets/RibbonIcons/settings.png" Text="Test9" />
+              </StackPanel>
+              <RibbonComboButton IconPath="/Assets/RibbonIcons/settings.png" Text="Coller">
+                <ComboBoxItem>ksdlfml</ComboBoxItem>
+                <ComboBoxItem>ksdnvbl</ComboBoxItem>
+              </RibbonComboButton>
+              <StackPanel>
+                <RibbonSmallButtonHGroup>
+                  <RibbonSmallButton IconPath="/Assets/RibbonIcons/settings.png" ToolTip.Tip="A small tooltip" />
+                  <RibbonSmallButton IconPath="/Assets/RibbonIcons/settings.png" />
+                  <RibbonSmallButton IconPath="/Assets/RibbonIcons/settings.png" />
+                </RibbonSmallButtonHGroup>
+              </StackPanel>
+            </StackPanel>
+          </RibbonTabGroup>
+        </StackPanel>
+      </RibbonTab>
+      <RibbonTab Header="RibbonTab 2">qsdfqsdf</RibbonTab>
+    </RibbonControl>
+    <Grid HorizontalAlignment="Center" VerticalAlignment="Center">
+      <CheckBox IsChecked="{Binding HasSystemDecorations, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=Window}, Mode=TwoWay}" Content="Use System Decorations"/>
+    </Grid>
+  </DockPanel>
+</local:RibbonWindow>

--- a/Avalonia.Ribbon.Sample/Views/MainWindow.xaml
+++ b/Avalonia.Ribbon.Sample/Views/MainWindow.xaml
@@ -5,7 +5,7 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:vm="clr-namespace:Avalonia.Ribbon.Samples.ViewModels;assembly=Avalonia.Ribbon.Sample"
-    xmlns:local="clr-namespace:Avalonia.Controls.Ribbon;assembly=Avalonia.Ribbon"
+    xmlns:local="clr-namespace:Avalonia.Controls.Ribbon;assembly=Avalonia.Controls.Ribbon"
     Title="Avalonia Ribbon"
     d:DesignHeight="450"
     d:DesignWidth="800"
@@ -13,67 +13,63 @@
     Icon="/Assets/avalonia-logo.ico"
     mc:Ignorable="d">
 
-  <Design.DataContext>
-    <vm:MainWindowViewModel />
-  </Design.DataContext>
-  <DockPanel>
-    <RibbonControl DockPanel.Dock="Top">
-      <RibbonControl.MenuItems>
-        <MenuItem Header="Item 1">
-          <MenuItem Header="SubItem 1"/>
-          <MenuItem Header="SubItem 2"/>
-        </MenuItem>
-        <MenuItem Header="Item 2">
-          <MenuItem Header="SubItem 1"/>
-          <MenuItem Header="SubItem 2"/>
-          <MenuItem Header="SubItem 3"/>
-        </MenuItem>
-      </RibbonControl.MenuItems>
-      <RibbonControl.MenuPlacesItems>
-        <ListBoxItem Content="Place 1"/>
-        <ListBoxItem Content="Place 2"/>
-        <ListBoxItem Content="Place 3"/>
-      </RibbonControl.MenuPlacesItems>
-      <RibbonTab Header="RibbonTab 1">
-        <StackPanel Orientation="Horizontal">
-          <RibbonTabGroup Text="Un premier groupe">
-            <StackPanel Orientation="Horizontal">
-              <RibbonButton IconPath="/Assets/RibbonIcons/settings.png" Text="Test3" />
-              <RibbonButton IconPath="/Assets/RibbonIcons/corner.png" Text="Test4" />
-              <RibbonButton IconPath="/Assets/RibbonIcons/chevron.png" Text="Test5" />
-              <RibbonButton IconPath="/Assets/RibbonIcons/settings.png" Text="Test6" />
-            </StackPanel>
-          </RibbonTabGroup>
-          <RibbonTabGroup Command="{Binding OnClickCommand}" Text="Paragraphe">
-            <StackPanel Orientation="Horizontal">
-              <StackPanel Orientation="Vertical">
-                <!--  Maximum 3 buttons per vertical stackpanel  -->
-                <RibbonLinearButton
+    <Design.DataContext>
+        <vm:MainWindowViewModel />
+    </Design.DataContext>
+    <DockPanel>
+        <Ribbon DockPanel.Dock="Top">
+            <Ribbon.MenuItems>
+                <MenuItem Header="Item 1">
+                    <MenuItem Header="SubItem 1"/>
+                    <MenuItem Header="SubItem 2"/>
+                </MenuItem>
+                <MenuItem Header="Item 2">
+                    <MenuItem Header="SubItem 1"/>
+                    <MenuItem Header="SubItem 2"/>
+                    <MenuItem Header="SubItem 3"/>
+                </MenuItem>
+            </Ribbon.MenuItems>
+            <Ribbon.MenuPlacesItems>
+                <ListBoxItem Content="Place 1"/>
+                <ListBoxItem Content="Place 2"/>
+                <ListBoxItem Content="Place 3"/>
+            </Ribbon.MenuPlacesItems>
+            <RibbonTab Header="RibbonTab 1">
+                <StackPanel Orientation="Horizontal">
+                    <RibbonTabGroup Text="Un premier groupe">
+                        <RibbonButton IconPath="/Assets/RibbonIcons/settings.png" Text="Test3" />
+                        <RibbonButton IconPath="/Assets/RibbonIcons/corner.png" Text="Test4" />
+                        <RibbonButton IconPath="/Assets/RibbonIcons/chevron.png" Text="Test5" />
+                        <RibbonButton IconPath="/Assets/RibbonIcons/settings.png" Text="Test6" />
+                    </RibbonTabGroup>
+                    <RibbonTabGroup Command="{Binding OnClickCommand}" Text="Paragraphe">
+                        <StackPanel Orientation="Vertical">
+                            <!--  Maximum 3 buttons per vertical stackpanel  -->
+                            <RibbonLinearButton
                     Command="{Binding OnClickCommand}"
                     IconPath="/Assets/RibbonIcons/corner.png"
                     Text="Reproduire la mise en forme" />
-                <RibbonLinearButton IconPath="/Assets/RibbonIcons/settings.png" Text="Test8" />
-                <RibbonLinearButton IconPath="/Assets/RibbonIcons/settings.png" Text="Test9" />
-              </StackPanel>
-              <RibbonComboButton IconPath="/Assets/RibbonIcons/settings.png" Text="Coller">
-                <ComboBoxItem>ksdlfml</ComboBoxItem>
-                <ComboBoxItem>ksdnvbl</ComboBoxItem>
-              </RibbonComboButton>
-              <StackPanel>
-                <RibbonSmallButtonHGroup>
-                  <RibbonSmallButton IconPath="/Assets/RibbonIcons/settings.png" ToolTip.Tip="A small tooltip" />
-                  <RibbonSmallButton IconPath="/Assets/RibbonIcons/settings.png" />
-                  <RibbonSmallButton IconPath="/Assets/RibbonIcons/settings.png" />
-                </RibbonSmallButtonHGroup>
-              </StackPanel>
-            </StackPanel>
-          </RibbonTabGroup>
-        </StackPanel>
-      </RibbonTab>
-      <RibbonTab Header="RibbonTab 2">qsdfqsdf</RibbonTab>
-    </RibbonControl>
-    <Grid HorizontalAlignment="Center" VerticalAlignment="Center">
-      <CheckBox IsChecked="{Binding HasSystemDecorations, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=Window}, Mode=TwoWay}" Content="Use System Decorations"/>
-    </Grid>
-  </DockPanel>
+                            <RibbonLinearButton IconPath="/Assets/RibbonIcons/settings.png" Text="Test8" />
+                            <RibbonLinearButton IconPath="/Assets/RibbonIcons/settings.png" Text="Test9" />
+                        </StackPanel>
+                        <RibbonComboButton IconPath="/Assets/RibbonIcons/settings.png" Text="Coller">
+                            <ComboBoxItem>ksdlfml</ComboBoxItem>
+                            <ComboBoxItem>ksdnvbl</ComboBoxItem>
+                        </RibbonComboButton>
+                        <StackPanel>
+                            <RibbonSmallButtonHGroup>
+                                <RibbonSmallButton IconPath="/Assets/RibbonIcons/settings.png" ToolTip.Tip="A small tooltip" />
+                                <RibbonSmallButton IconPath="/Assets/RibbonIcons/settings.png" />
+                                <RibbonSmallButton IconPath="/Assets/RibbonIcons/settings.png" />
+                            </RibbonSmallButtonHGroup>
+                        </StackPanel>
+                    </RibbonTabGroup>
+                </StackPanel>
+            </RibbonTab>
+            <RibbonTab Header="RibbonTab 2"/>
+        </Ribbon>
+        <Grid HorizontalAlignment="Center" VerticalAlignment="Center">
+            <CheckBox IsChecked="{Binding HasSystemDecorations, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=Window}, Mode=TwoWay}" Content="Use System Decorations"/>
+        </Grid>
+    </DockPanel>
 </local:RibbonWindow>

--- a/Avalonia.Ribbon.Sample/Views/MainWindow.xaml
+++ b/Avalonia.Ribbon.Sample/Views/MainWindow.xaml
@@ -12,10 +12,9 @@
     HasSystemDecorations="false"
     Icon="/Assets/avalonia-logo.ico"
     mc:Ignorable="d">
-
-    <Design.DataContext>
+    <ribbon:RibbonWindow.DataContext>
         <vm:MainWindowViewModel />
-    </Design.DataContext>
+    </ribbon:RibbonWindow.DataContext>
     <DockPanel>
         <ribbon:Ribbon DockPanel.Dock="Top">
             <ribbon:Ribbon.MenuItems>
@@ -37,30 +36,72 @@
             <ribbon:RibbonTab Header="RibbonTab 1">
                 <StackPanel Orientation="Horizontal">
                     <ribbon:RibbonTabGroup Text="Un premier groupe">
-                        <ribbon:RibbonButton IconPath="/Assets/RibbonIcons/settings.png" Text="Test3" />
-                        <ribbon:RibbonButton IconPath="/Assets/RibbonIcons/corner.png" Text="Test4" />
-                        <ribbon:RibbonButton IconPath="/Assets/RibbonIcons/chevron.png" Text="Test5" />
-                        <ribbon:RibbonButton IconPath="/Assets/RibbonIcons/settings.png" Text="Test6" />
+                        <ribbon:RibbonButton Content="Test3">
+                            <ribbon:RibbonButton.LargeIcon>
+                                <Image Source="/Assets/RibbonIcons/settings.png" Width="32" Height="32"/>
+                            </ribbon:RibbonButton.LargeIcon>
+                        </ribbon:RibbonButton>
+                        <ribbon:RibbonButton Content="Test4">
+                            <ribbon:RibbonButton.LargeIcon>
+                                <Image Source="/Assets/RibbonIcons/corner.png" Width="32" Height="32"/>
+                            </ribbon:RibbonButton.LargeIcon>
+                        </ribbon:RibbonButton>
+                        <ribbon:RibbonButton Content="Test5">
+                            <ribbon:RibbonButton.LargeIcon>
+                                <Image Source="/Assets/RibbonIcons/chevron.png" Width="32" Height="32"/>
+                            </ribbon:RibbonButton.LargeIcon>
+                        </ribbon:RibbonButton>
+                        <ribbon:RibbonButton Content="Test6">
+                            <ribbon:RibbonButton.LargeIcon>
+                                <Image Source="/Assets/RibbonIcons/settings.png" Width="32" Height="32"/>
+                            </ribbon:RibbonButton.LargeIcon>
+                        </ribbon:RibbonButton>
                     </ribbon:RibbonTabGroup>
                     <ribbon:RibbonTabGroup Command="{Binding OnClickCommand}" Text="Paragraphe">
                         <StackPanel Orientation="Vertical">
                             <!--  Maximum 3 buttons per vertical stackpanel  -->
-                            <ribbon:RibbonLinearButton
+                            <ribbon:RibbonButton Size="Medium"
                     Command="{Binding OnClickCommand}"
-                    IconPath="/Assets/RibbonIcons/corner.png"
-                    Text="Reproduire la mise en forme" />
-                            <ribbon:RibbonLinearButton IconPath="/Assets/RibbonIcons/settings.png" Text="Test8" />
-                            <ribbon:RibbonLinearButton IconPath="/Assets/RibbonIcons/settings.png" Text="Test9" />
+                    Content="Reproduire la mise en forme">
+                                <ribbon:RibbonButton.Icon>
+                                    <Image Source="/Assets/RibbonIcons/settings.png" Width="16" Height="16"/>
+                                </ribbon:RibbonButton.Icon>
+                            </ribbon:RibbonButton>
+                            <ribbon:RibbonButton Size="Medium" Content="Test8">
+                                <ribbon:RibbonButton.Icon>
+                                    <Image Source="/Assets/RibbonIcons/settings.png" Width="16" Height="16"/>
+                                </ribbon:RibbonButton.Icon>
+                            </ribbon:RibbonButton>
+                            <ribbon:RibbonButton Size="Medium" Content="Test9">
+                                <ribbon:RibbonButton.Icon>
+                                    <Image Source="/Assets/RibbonIcons/settings.png" Width="16" Height="16"/>
+                                </ribbon:RibbonButton.Icon>
+                            </ribbon:RibbonButton>
                         </StackPanel>
-                        <ribbon:RibbonComboButton IconPath="/Assets/RibbonIcons/settings.png" Text="Coller">
+                        <ribbon:RibbonComboButton Content="Coller">
+                            <ribbon:RibbonComboButton.LargeIcon>
+                                <Image Source="/Assets/RibbonIcons/settings.png" Width="32" Height="32"/>
+                            </ribbon:RibbonComboButton.LargeIcon>
                             <ComboBoxItem>ksdlfml</ComboBoxItem>
                             <ComboBoxItem>ksdnvbl</ComboBoxItem>
                         </ribbon:RibbonComboButton>
                         <StackPanel>
                             <ribbon:RibbonSmallButtonHGroup>
-                                <ribbon:RibbonSmallButton IconPath="/Assets/RibbonIcons/settings.png" ToolTip.Tip="A small tooltip" />
-                                <ribbon:RibbonSmallButton IconPath="/Assets/RibbonIcons/settings.png" />
-                                <ribbon:RibbonSmallButton IconPath="/Assets/RibbonIcons/settings.png" />
+                                <ribbon:RibbonButton Size="Small" ToolTip.Tip="A small tooltip">
+                                    <ribbon:RibbonButton.Icon>
+                                        <Image Source="/Assets/RibbonIcons/settings.png" Width="16" Height="16"/>
+                                    </ribbon:RibbonButton.Icon>
+                                </ribbon:RibbonButton>
+                                <ribbon:RibbonButton Size="Small">
+                                    <ribbon:RibbonButton.Icon>
+                                        <Image Source="/Assets/RibbonIcons/settings.png" Width="16" Height="16"/>
+                                    </ribbon:RibbonButton.Icon>
+                                </ribbon:RibbonButton>
+                                <ribbon:RibbonButton Size="Small">
+                                    <ribbon:RibbonButton.Icon>
+                                        <Image Source="/Assets/RibbonIcons/settings.png" Width="16" Height="16"/>
+                                    </ribbon:RibbonButton.Icon>
+                                </ribbon:RibbonButton>
                             </ribbon:RibbonSmallButtonHGroup>
                         </StackPanel>
                     </ribbon:RibbonTabGroup>
@@ -71,22 +112,48 @@
                     <ribbon:RibbonTabGroup Command="{Binding OnClickCommand}" Text="Paragraphe">
                         <StackPanel Orientation="Vertical">
                             <!--  Maximum 3 buttons per vertical stackpanel  -->
-                            <ribbon:RibbonLinearButton
+                            <ribbon:RibbonButton Size="Medium"
                     Command="{Binding OnClickCommand}"
-                    IconPath="/Assets/RibbonIcons/corner.png"
-                    Text="Reproduire la mise en forme" />
-                            <ribbon:RibbonLinearButton IconPath="/Assets/RibbonIcons/settings.png" Text="Test8" />
-                            <ribbon:RibbonLinearButton IconPath="/Assets/RibbonIcons/settings.png" Text="Test9" />
+                    Content="Reproduire la mise en forme">
+                                <ribbon:RibbonButton.Icon>
+                                    <Image Source="/Assets/RibbonIcons/settings.png" Width="16" Height="16"/>
+                                </ribbon:RibbonButton.Icon>
+                            </ribbon:RibbonButton>
+                            <ribbon:RibbonButton Size="Medium" Content="Test8">
+                                <ribbon:RibbonButton.Icon>
+                                    <Image Source="/Assets/RibbonIcons/settings.png" Width="16" Height="16"/>
+                                </ribbon:RibbonButton.Icon>
+                            </ribbon:RibbonButton>
+                            <ribbon:RibbonButton Size="Medium" Content="Test9">
+                                <ribbon:RibbonButton.Icon>
+                                    <Image Source="/Assets/RibbonIcons/settings.png" Width="16" Height="16"/>
+                                </ribbon:RibbonButton.Icon>
+                            </ribbon:RibbonButton>
                         </StackPanel>
-                        <ribbon:RibbonComboButton IconPath="/Assets/RibbonIcons/settings.png" Text="Coller">
+                        <ribbon:RibbonComboButton Content="Coller">
+                            <ribbon:RibbonComboButton.Icon>
+                                <Image Source="/Assets/RibbonIcons/settings.png" Width="16" Height="16"/>
+                            </ribbon:RibbonComboButton.Icon>
                             <ComboBoxItem>ksdlfml</ComboBoxItem>
                             <ComboBoxItem>ksdnvbl</ComboBoxItem>
                         </ribbon:RibbonComboButton>
                         <StackPanel>
                             <ribbon:RibbonSmallButtonHGroup>
-                                <ribbon:RibbonSmallButton IconPath="/Assets/RibbonIcons/settings.png" ToolTip.Tip="A small tooltip" />
-                                <ribbon:RibbonSmallButton IconPath="/Assets/RibbonIcons/settings.png" />
-                                <ribbon:RibbonSmallButton IconPath="/Assets/RibbonIcons/settings.png" />
+                                <ribbon:RibbonButton Size="Small" ToolTip.Tip="A small tooltip">
+                                    <ribbon:RibbonButton.Icon>
+                                        <Image Source="/Assets/RibbonIcons/settings.png" Width="16" Height="16"/>
+                                    </ribbon:RibbonButton.Icon>
+                                </ribbon:RibbonButton>
+                                <ribbon:RibbonButton Size="Small">
+                                    <ribbon:RibbonButton.Icon>
+                                        <Image Source="/Assets/RibbonIcons/settings.png" Width="16" Height="16"/>
+                                    </ribbon:RibbonButton.Icon>
+                                </ribbon:RibbonButton>
+                                <ribbon:RibbonButton Size="Small">
+                                    <ribbon:RibbonButton.Icon>
+                                        <Image Source="/Assets/RibbonIcons/settings.png" Width="16" Height="16"/>
+                                    </ribbon:RibbonButton.Icon>
+                                </ribbon:RibbonButton>
                             </ribbon:RibbonSmallButtonHGroup>
                         </StackPanel>
                     </ribbon:RibbonTabGroup>
@@ -95,10 +162,26 @@
             <ribbon:RibbonTab Header="RibbonTab 3">
                 <StackPanel Orientation="Horizontal">
                     <ribbon:RibbonTabGroup Text="Un premier groupe">
-                        <ribbon:RibbonButton IconPath="/Assets/RibbonIcons/settings.png" Text="Test3" />
-                        <ribbon:RibbonButton IconPath="/Assets/RibbonIcons/corner.png" Text="Test4" />
-                        <ribbon:RibbonButton IconPath="/Assets/RibbonIcons/chevron.png" Text="Test5" />
-                        <ribbon:RibbonButton IconPath="/Assets/RibbonIcons/settings.png" Text="Test6" />
+                        <ribbon:RibbonButton Content="Test3">
+                            <ribbon:RibbonButton.LargeIcon>
+                                <Image Source="/Assets/RibbonIcons/settings.png" Width="32" Height="32"/>
+                            </ribbon:RibbonButton.LargeIcon>
+                        </ribbon:RibbonButton>
+                        <ribbon:RibbonButton Content="Test4">
+                            <ribbon:RibbonButton.LargeIcon>
+                                <Image Source="/Assets/RibbonIcons/corner.png" Width="32" Height="32"/>
+                            </ribbon:RibbonButton.LargeIcon>
+                        </ribbon:RibbonButton>
+                        <ribbon:RibbonButton Content="Test5">
+                            <ribbon:RibbonButton.LargeIcon>
+                                <Image Source="/Assets/RibbonIcons/chevron.png" Width="32" Height="32"/>
+                            </ribbon:RibbonButton.LargeIcon>
+                        </ribbon:RibbonButton>
+                        <ribbon:RibbonButton Content="Test6">
+                            <ribbon:RibbonButton.LargeIcon>
+                                <Image Source="/Assets/RibbonIcons/settings.png" Width="32" Height="32"/>
+                            </ribbon:RibbonButton.LargeIcon>
+                        </ribbon:RibbonButton>
                     </ribbon:RibbonTabGroup>
                 </StackPanel>
             </ribbon:RibbonTab>

--- a/Avalonia.Ribbon.Sample/Views/MainWindow.xaml
+++ b/Avalonia.Ribbon.Sample/Views/MainWindow.xaml
@@ -1,11 +1,11 @@
-﻿<local:RibbonWindow
+﻿<ribbon:RibbonWindow
     x:Class="Avalonia.Ribbon.Samples.Views.MainWindow"
     xmlns="https://github.com/avaloniaui"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:vm="clr-namespace:Avalonia.Ribbon.Samples.ViewModels;assembly=Avalonia.Ribbon.Sample"
-    xmlns:local="clr-namespace:Avalonia.Controls.Ribbon;assembly=Avalonia.Controls.Ribbon"
+    xmlns:ribbon="clr-namespace:Avalonia.Controls.Ribbon;assembly=Avalonia.Controls.Ribbon"
     Title="Avalonia Ribbon"
     d:DesignHeight="450"
     d:DesignWidth="800"
@@ -17,8 +17,8 @@
         <vm:MainWindowViewModel />
     </Design.DataContext>
     <DockPanel>
-        <Ribbon DockPanel.Dock="Top">
-            <Ribbon.MenuItems>
+        <ribbon:Ribbon DockPanel.Dock="Top">
+            <ribbon:Ribbon.MenuItems>
                 <MenuItem Header="Item 1">
                     <MenuItem Header="SubItem 1"/>
                     <MenuItem Header="SubItem 2"/>
@@ -28,48 +28,83 @@
                     <MenuItem Header="SubItem 2"/>
                     <MenuItem Header="SubItem 3"/>
                 </MenuItem>
-            </Ribbon.MenuItems>
-            <Ribbon.MenuPlacesItems>
+            </ribbon:Ribbon.MenuItems>
+            <ribbon:Ribbon.MenuPlacesItems>
                 <ListBoxItem Content="Place 1"/>
                 <ListBoxItem Content="Place 2"/>
                 <ListBoxItem Content="Place 3"/>
-            </Ribbon.MenuPlacesItems>
-            <RibbonTab Header="RibbonTab 1">
+            </ribbon:Ribbon.MenuPlacesItems>
+            <ribbon:RibbonTab Header="RibbonTab 1">
                 <StackPanel Orientation="Horizontal">
-                    <RibbonTabGroup Text="Un premier groupe">
-                        <RibbonButton IconPath="/Assets/RibbonIcons/settings.png" Text="Test3" />
-                        <RibbonButton IconPath="/Assets/RibbonIcons/corner.png" Text="Test4" />
-                        <RibbonButton IconPath="/Assets/RibbonIcons/chevron.png" Text="Test5" />
-                        <RibbonButton IconPath="/Assets/RibbonIcons/settings.png" Text="Test6" />
-                    </RibbonTabGroup>
-                    <RibbonTabGroup Command="{Binding OnClickCommand}" Text="Paragraphe">
+                    <ribbon:RibbonTabGroup Text="Un premier groupe">
+                        <ribbon:RibbonButton IconPath="/Assets/RibbonIcons/settings.png" Text="Test3" />
+                        <ribbon:RibbonButton IconPath="/Assets/RibbonIcons/corner.png" Text="Test4" />
+                        <ribbon:RibbonButton IconPath="/Assets/RibbonIcons/chevron.png" Text="Test5" />
+                        <ribbon:RibbonButton IconPath="/Assets/RibbonIcons/settings.png" Text="Test6" />
+                    </ribbon:RibbonTabGroup>
+                    <ribbon:RibbonTabGroup Command="{Binding OnClickCommand}" Text="Paragraphe">
                         <StackPanel Orientation="Vertical">
                             <!--  Maximum 3 buttons per vertical stackpanel  -->
-                            <RibbonLinearButton
+                            <ribbon:RibbonLinearButton
                     Command="{Binding OnClickCommand}"
                     IconPath="/Assets/RibbonIcons/corner.png"
                     Text="Reproduire la mise en forme" />
-                            <RibbonLinearButton IconPath="/Assets/RibbonIcons/settings.png" Text="Test8" />
-                            <RibbonLinearButton IconPath="/Assets/RibbonIcons/settings.png" Text="Test9" />
+                            <ribbon:RibbonLinearButton IconPath="/Assets/RibbonIcons/settings.png" Text="Test8" />
+                            <ribbon:RibbonLinearButton IconPath="/Assets/RibbonIcons/settings.png" Text="Test9" />
                         </StackPanel>
-                        <RibbonComboButton IconPath="/Assets/RibbonIcons/settings.png" Text="Coller">
+                        <ribbon:RibbonComboButton IconPath="/Assets/RibbonIcons/settings.png" Text="Coller">
                             <ComboBoxItem>ksdlfml</ComboBoxItem>
                             <ComboBoxItem>ksdnvbl</ComboBoxItem>
-                        </RibbonComboButton>
+                        </ribbon:RibbonComboButton>
                         <StackPanel>
-                            <RibbonSmallButtonHGroup>
-                                <RibbonSmallButton IconPath="/Assets/RibbonIcons/settings.png" ToolTip.Tip="A small tooltip" />
-                                <RibbonSmallButton IconPath="/Assets/RibbonIcons/settings.png" />
-                                <RibbonSmallButton IconPath="/Assets/RibbonIcons/settings.png" />
-                            </RibbonSmallButtonHGroup>
+                            <ribbon:RibbonSmallButtonHGroup>
+                                <ribbon:RibbonSmallButton IconPath="/Assets/RibbonIcons/settings.png" ToolTip.Tip="A small tooltip" />
+                                <ribbon:RibbonSmallButton IconPath="/Assets/RibbonIcons/settings.png" />
+                                <ribbon:RibbonSmallButton IconPath="/Assets/RibbonIcons/settings.png" />
+                            </ribbon:RibbonSmallButtonHGroup>
                         </StackPanel>
-                    </RibbonTabGroup>
+                    </ribbon:RibbonTabGroup>
                 </StackPanel>
-            </RibbonTab>
-            <RibbonTab Header="RibbonTab 2"/>
-        </Ribbon>
+            </ribbon:RibbonTab>
+            <ribbon:RibbonTab Header="RibbonTab 2">
+                <StackPanel Orientation="Horizontal">
+                    <ribbon:RibbonTabGroup Command="{Binding OnClickCommand}" Text="Paragraphe">
+                        <StackPanel Orientation="Vertical">
+                            <!--  Maximum 3 buttons per vertical stackpanel  -->
+                            <ribbon:RibbonLinearButton
+                    Command="{Binding OnClickCommand}"
+                    IconPath="/Assets/RibbonIcons/corner.png"
+                    Text="Reproduire la mise en forme" />
+                            <ribbon:RibbonLinearButton IconPath="/Assets/RibbonIcons/settings.png" Text="Test8" />
+                            <ribbon:RibbonLinearButton IconPath="/Assets/RibbonIcons/settings.png" Text="Test9" />
+                        </StackPanel>
+                        <ribbon:RibbonComboButton IconPath="/Assets/RibbonIcons/settings.png" Text="Coller">
+                            <ComboBoxItem>ksdlfml</ComboBoxItem>
+                            <ComboBoxItem>ksdnvbl</ComboBoxItem>
+                        </ribbon:RibbonComboButton>
+                        <StackPanel>
+                            <ribbon:RibbonSmallButtonHGroup>
+                                <ribbon:RibbonSmallButton IconPath="/Assets/RibbonIcons/settings.png" ToolTip.Tip="A small tooltip" />
+                                <ribbon:RibbonSmallButton IconPath="/Assets/RibbonIcons/settings.png" />
+                                <ribbon:RibbonSmallButton IconPath="/Assets/RibbonIcons/settings.png" />
+                            </ribbon:RibbonSmallButtonHGroup>
+                        </StackPanel>
+                    </ribbon:RibbonTabGroup>
+                </StackPanel>
+            </ribbon:RibbonTab>
+            <ribbon:RibbonTab Header="RibbonTab 3">
+                <StackPanel Orientation="Horizontal">
+                    <ribbon:RibbonTabGroup Text="Un premier groupe">
+                        <ribbon:RibbonButton IconPath="/Assets/RibbonIcons/settings.png" Text="Test3" />
+                        <ribbon:RibbonButton IconPath="/Assets/RibbonIcons/corner.png" Text="Test4" />
+                        <ribbon:RibbonButton IconPath="/Assets/RibbonIcons/chevron.png" Text="Test5" />
+                        <ribbon:RibbonButton IconPath="/Assets/RibbonIcons/settings.png" Text="Test6" />
+                    </ribbon:RibbonTabGroup>
+                </StackPanel>
+            </ribbon:RibbonTab>
+        </ribbon:Ribbon>
         <Grid HorizontalAlignment="Center" VerticalAlignment="Center">
             <CheckBox IsChecked="{Binding HasSystemDecorations, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=Window}, Mode=TwoWay}" Content="Use System Decorations"/>
         </Grid>
     </DockPanel>
-</local:RibbonWindow>
+</ribbon:RibbonWindow>

--- a/Avalonia.Ribbon.Sample/Views/MainWindow.xaml.cs
+++ b/Avalonia.Ribbon.Sample/Views/MainWindow.xaml.cs
@@ -1,10 +1,11 @@
 ﻿using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Controls.Ribbon;
 using Avalonia.Markup.Xaml;
 
 namespace Avalonia.Ribbon.Samples.Views
 {
-    public class MainWindow : Window
+    public class MainWindow : RibbonWindow
     {
         public MainWindow()
         {

--- a/Avalonia.Ribbon/IRibbonControl.cs
+++ b/Avalonia.Ribbon/IRibbonControl.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Avalonia.Controls.Ribbon
+{
+    public interface IRibbonControl
+    {
+        RibbonControlSize Size
+        {
+            get;
+            set;
+        }
+
+        bool CanAddToQuickAccessToolbar
+        {
+            get;
+            set;
+        }
+
+        object Icon
+        {
+            get;
+            set;
+        }
+    }
+
+    public enum RibbonControlSize
+    {
+        Small,
+        Medium,
+        Large
+    }
+}

--- a/Avalonia.Ribbon/Ribbon.cs
+++ b/Avalonia.Ribbon/Ribbon.cs
@@ -66,16 +66,12 @@ namespace Avalonia.Controls.Ribbon
             {
                 if (e.Delta.Y > 0)
                 {
-                    if (SelectedIndex == 0)
-                        SelectedIndex = ItemCount - 1;
-                    else
+                    if (SelectedIndex > 0)
                         SelectedIndex--;
                 }
                 else if (e.Delta.Y < 0)
                 {
-                    if (SelectedIndex == (ItemCount - 1))
-                        SelectedIndex = 0;
-                    else
+                    if (SelectedIndex < (ItemCount - 1))
                         SelectedIndex++;
                 }
             }

--- a/Avalonia.Ribbon/Ribbon.cs
+++ b/Avalonia.Ribbon/Ribbon.cs
@@ -8,7 +8,7 @@ using System.Collections;
 
 namespace Avalonia.Controls.Ribbon
 {
-    public class RibbonControl : TabControl, IStyleable
+    public class Ribbon : TabControl, IStyleable
     {
         private IEnumerable _menuItems = new AvaloniaList<object>();
         private IEnumerable _menuPlacesItems = new AvaloniaList<object>();
@@ -28,19 +28,19 @@ namespace Avalonia.Controls.Ribbon
         public static readonly StyledProperty<IBrush> RemainingTabControlHeaderColorProperty;
         public static readonly StyledProperty<bool> IsCollapsedProperty;
         public static readonly StyledProperty<bool> IsMenuOpenProperty;
-        public static readonly DirectProperty<RibbonControl, IEnumerable> MenuItemsProperty;
-        public static readonly DirectProperty<RibbonControl, IEnumerable> MenuPlacesItemsProperty;
+        public static readonly DirectProperty<Ribbon, IEnumerable> MenuItemsProperty;
+        public static readonly DirectProperty<Ribbon, IEnumerable> MenuPlacesItemsProperty;
 
-        static RibbonControl()
+        static Ribbon()
         {
-            RemainingTabControlHeaderColorProperty = AvaloniaProperty.Register<RibbonControl, IBrush>(nameof(RemainingTabControlHeaderColor));
-            IsCollapsedProperty = AvaloniaProperty.Register<RibbonControl, bool>(nameof(IsCollapsed));
-            IsMenuOpenProperty = AvaloniaProperty.Register<RibbonControl, bool>(nameof(IsMenuOpen));
-            MenuItemsProperty = MenuBase.ItemsProperty.AddOwner<RibbonControl>(x => x.MenuItems, (x, v) => x.MenuItems = v);
-            MenuPlacesItemsProperty = ItemsControl.ItemsProperty.AddOwner<RibbonControl>(x => x.MenuPlacesItems, (x, v) => x.MenuPlacesItems = v);
+            RemainingTabControlHeaderColorProperty = AvaloniaProperty.Register<Ribbon, IBrush>(nameof(RemainingTabControlHeaderColor));
+            IsCollapsedProperty = AvaloniaProperty.Register<Ribbon, bool>(nameof(IsCollapsed));
+            IsMenuOpenProperty = AvaloniaProperty.Register<Ribbon, bool>(nameof(IsMenuOpen));
+            MenuItemsProperty = MenuBase.ItemsProperty.AddOwner<Ribbon>(x => x.MenuItems, (x, v) => x.MenuItems = v);
+            MenuPlacesItemsProperty = ItemsControl.ItemsProperty.AddOwner<Ribbon>(x => x.MenuPlacesItems, (x, v) => x.MenuPlacesItems = v);
         }
 
-        Type IStyleable.StyleKey => typeof(RibbonControl);
+        Type IStyleable.StyleKey => typeof(Ribbon);
 
         public bool IsCollapsed
         {

--- a/Avalonia.Ribbon/RibbonButton.cs
+++ b/Avalonia.Ribbon/RibbonButton.cs
@@ -4,16 +4,20 @@ using System;
 
 namespace Avalonia.Controls.Ribbon
 {
-    public class RibbonButton : Button, IStyleable
+    public class RibbonButton : Button, IStyleable, IRibbonControl
     {
 
         public static readonly StyledProperty<string> TextProperty;
-        public static readonly StyledProperty<IBitmap> IconPathProperty;
+        public static readonly StyledProperty<object> IconProperty = AvaloniaProperty.Register<RibbonButton, object>(nameof(Icon));
+        public static readonly StyledProperty<object> LargeIconProperty = AvaloniaProperty.Register<RibbonButton, object>(nameof(LargeIcon));
+        public static readonly StyledProperty<RibbonControlSize> SizeProperty;
+        public static readonly StyledProperty<bool> CanAddToQuickAccessToolbarProperty;
 
         static RibbonButton()
         {
             TextProperty = AvaloniaProperty.Register<RibbonButton, string>(nameof(Text));
-            IconPathProperty = AvaloniaProperty.Register<RibbonButton, IBitmap>(nameof(IconPath));
+            SizeProperty = AvaloniaProperty.Register<RibbonButton, RibbonControlSize>(nameof(RibbonControlSize), RibbonControlSize.Large);
+            CanAddToQuickAccessToolbarProperty = AvaloniaProperty.Register<RibbonButton, bool>(nameof(CanAddToQuickAccessToolbar), true);
         }
 
         Type IStyleable.StyleKey => typeof(RibbonButton);
@@ -23,13 +27,31 @@ namespace Avalonia.Controls.Ribbon
             get { return GetValue(TextProperty); }
             set { SetValue(TextProperty, value); }
         }
-
-        public IBitmap IconPath
+        
+        public object Icon
         {
-            get { return GetValue(IconPathProperty); }
-            set { SetValue(IconPathProperty, value); }
+            get => GetValue(IconProperty);
+            set => SetValue(IconProperty, value);
         }
 
+        public object LargeIcon
+        {
+            get => GetValue(LargeIconProperty);
+            set => SetValue(LargeIconProperty, value);
+        }
+
+
+        public RibbonControlSize Size
+        {
+            get => GetValue(SizeProperty);
+            set => SetValue(SizeProperty, value);
+        }
+
+        public bool CanAddToQuickAccessToolbar
+        {
+            get => GetValue(CanAddToQuickAccessToolbarProperty);
+            set => SetValue(CanAddToQuickAccessToolbarProperty, value);
+        }
     }
 
 }

--- a/Avalonia.Ribbon/RibbonComboButton.cs
+++ b/Avalonia.Ribbon/RibbonComboButton.cs
@@ -4,29 +4,54 @@ using System;
 
 namespace Avalonia.Controls.Ribbon
 {
-    public class RibbonComboButton : ComboBox, IStyleable
+    public class RibbonComboButton : ComboBox, IStyleable, IRibbonControl
     {
-        public static readonly StyledProperty<string> TextProperty;
-        public static readonly StyledProperty<IBitmap> IconPathProperty;
+        public static readonly StyledProperty<object> ContentProperty;
+        public static readonly StyledProperty<object> IconProperty;
+        public static readonly StyledProperty<object> LargeIconProperty;
+        public static readonly StyledProperty<RibbonControlSize> SizeProperty;
+        public static readonly StyledProperty<bool> CanAddToQuickAccessToolbarProperty;
 
         static RibbonComboButton()
         {
-            TextProperty = AvaloniaProperty.Register<RibbonComboButton, string>(nameof(Text));
-            IconPathProperty = AvaloniaProperty.Register<RibbonComboButton, IBitmap>(nameof(IconPath));
+            ContentProperty = RibbonButton.ContentProperty.AddOwner<RibbonComboButton>();
+            IconProperty = RibbonButton.IconProperty.AddOwner<RibbonComboButton>();
+            LargeIconProperty = AvaloniaProperty.Register<RibbonButton, object>(nameof(LargeIcon), null);
+            SizeProperty = RibbonButton.SizeProperty.AddOwner<RibbonComboButton>();
+            CanAddToQuickAccessToolbarProperty = RibbonButton.CanAddToQuickAccessToolbarProperty.AddOwner<RibbonComboButton>();
         }
 
         Type IStyleable.StyleKey => typeof(RibbonComboButton);
 
-        public string Text
+        public object Content
         {
-            get { return GetValue(TextProperty); }
-            set { SetValue(TextProperty, value); }
+            get => GetValue(ContentProperty);
+            set => SetValue(ContentProperty, value);
         }
 
-        public IBitmap IconPath
+        public object Icon
         {
-            get { return GetValue(IconPathProperty); }
-            set { SetValue(IconPathProperty, value); }
+            get => GetValue(IconProperty);
+            set => SetValue(IconProperty, value);
+        }
+
+        public object LargeIcon
+        {
+            get => GetValue(LargeIconProperty);
+            set => SetValue(LargeIconProperty, value);
+        }
+
+
+        public RibbonControlSize Size
+        {
+            get => GetValue(SizeProperty);
+            set => SetValue(SizeProperty, value);
+        }
+
+        public bool CanAddToQuickAccessToolbar
+        {
+            get => GetValue(CanAddToQuickAccessToolbarProperty);
+            set => SetValue(CanAddToQuickAccessToolbarProperty, value);
         }
     }
 }

--- a/Avalonia.Ribbon/RibbonTabGroup.cs
+++ b/Avalonia.Ribbon/RibbonTabGroup.cs
@@ -4,7 +4,7 @@ using System.Windows.Input;
 
 namespace Avalonia.Controls.Ribbon
 {
-    public class RibbonTabGroup : ContentControl, IStyleable
+    public class RibbonTabGroup : ItemsControl, IStyleable
     {
         public static readonly StyledProperty<string> TextProperty;
         public static readonly DirectProperty<RibbonTabGroup, ICommand> CommandProperty;
@@ -24,7 +24,7 @@ namespace Avalonia.Controls.Ribbon
             get { return GetValue(TextProperty); }
             set { SetValue(TextProperty, value); }
         }
-        
+
         public ICommand Command
         {
             get { return _command; }
@@ -33,5 +33,3 @@ namespace Avalonia.Controls.Ribbon
 
     }
 }
-
-

--- a/Avalonia.Ribbon/RibbonWindow.cs
+++ b/Avalonia.Ribbon/RibbonWindow.cs
@@ -5,16 +5,34 @@ using Avalonia.Media.Imaging;
 using Avalonia.Styling;
 using Avalonia.VisualTree;
 using System;
+using System.Collections.Generic;
 
 namespace Avalonia.Controls.Ribbon
 {
-    public class RibbonWindow : ItemsControl, IStyleable
+    public class RibbonWindow : Window, IStyleable
     {
         public static readonly StyledProperty<IBrush> TitleBarColorProperty;
+        
+        /*public static readonly StyledProperty<WindowState> WindowStateProperty;
+        public WindowState WindowState
+        {
+            get => GetValue(WindowStateProperty);
+            set => SetValue(WindowStateProperty, value);
+        }
+
+        public static readonly DirectProperty<RibbonWindow, bool> IsActiveProperty;
+        public bool IsActive
+        {
+            get => GetValue(IsActiveProperty);
+            set => SetValue(IsActiveProperty, value);
+        }*/
 
         static RibbonWindow()
         {
             TitleBarColorProperty = AvaloniaProperty.Register<RibbonWindow, IBrush>(nameof(TitleBarColor));
+            /*WindowStateProperty = Window.WindowStateProperty.AddOwner<RibbonWindow>();
+            IsActiveProperty = Window.IsActiveProperty.AddOwner<RibbonWindow>(x => x.IsActive, (x, o) => x.IsActive = o);*/
+            //HasSystemDecorationsProperty.OverrideDefaultValue(typeof(RibbonWindow), false);
         }
 
         Type IStyleable.StyleKey => typeof(RibbonWindow);
@@ -42,58 +60,83 @@ namespace Avalonia.Controls.Ribbon
 
         protected override void OnTemplateApplied(TemplateAppliedEventArgs e)
         {
-            var window = (Window)this.GetVisualRoot();
-            var titleBar = GetControl<Control>(e, "TitleBar");
-
-            if (Environment.OSVersion.Platform == PlatformID.Win32NT)
+            base.OnTemplateApplied(e);
+            var window = this;// (Window)this.GetVisualRoot();
+            try
             {
-                
-                titleBar.DoubleTapped += delegate
+                var titleBar = GetControl<Control>(e, "TitleBar");
+
+                if (Environment.OSVersion.Platform == PlatformID.Win32NT)
                 {
-                    window.WindowState = ((Window)this.GetVisualRoot()).WindowState == WindowState.Maximized ? WindowState.Normal : WindowState.Maximized;
-                };
-                window.PropertyChanged += (sender, propertyChnagedArgs) =>
-                {
-                    if (propertyChnagedArgs.Property.Name.Equals(nameof(WindowState)))
+
+                    titleBar.DoubleTapped += delegate
                     {
-                        if (window.WindowState.HasFlag(WindowState.Maximized))
-                            GetControl<Image>(e, "ImageMaximizeButton").Source = new Bitmap("./Assets/already_maximized.png");
-                        else
-                            GetControl<Image>(e, "ImageMaximizeButton").Source = new Bitmap("./Assets/maximize.png");
-                    }
+                        window.WindowState = ((Window)this.GetVisualRoot()).WindowState == WindowState.Maximized ? WindowState.Normal : WindowState.Maximized;
+                    };
+                    /*window.Activated += (sneder, args) => IsActive = true;
+                    window.Deactivated += (sneder, args) => IsActive = false;
+                    window.PositionChanged += (sneder, args) => WindowState = window.WindowState;*/
+                    /*window.PropertyChanged += (sender, propertyChnagedArgs) =>
+                    {
+                        if (propertyChnagedArgs.Property.Name.Equals(nameof(WindowState)))
+                        {
+                            /*if (window.WindowState.HasFlag(WindowState.Maximized))
+                                GetControl<Image>(e, "ImageMaximizeButton").Source = new Bitmap("./Assets/already_maximized.png");
+                            else
+                                GetControl<Image>(e, "ImageMaximizeButton").Source = new Bitmap("./Assets/maximize.png");*
+                            if (WindowState != window.WindowState)
+                                WindowState = window.WindowState;
+                        }
+                        else if (propertyChnagedArgs.Property.Name.Equals(nameof(IsActive)))
+                        {
+                            if (IsActive != window.IsActive)
+                                IsActive = window.IsActive;
+                        }
+                    };*/
+                }
+
+                titleBar.PointerPressed += (object sender, PointerPressedEventArgs ep) =>
+                {
+                    window.PlatformImpl?.BeginMoveDrag(ep);
+                };
+
+                try
+                {
+                    SetupSide("Left_top", StandardCursorType.LeftSide, WindowEdge.West, ref e);
+                    SetupSide("Left_mid", StandardCursorType.LeftSide, WindowEdge.West, ref e);
+                    SetupSide("Left_bottom", StandardCursorType.LeftSide, WindowEdge.West, ref e);
+                    SetupSide("Right_top", StandardCursorType.RightSide, WindowEdge.East, ref e);
+                    SetupSide("Right_mid", StandardCursorType.RightSide, WindowEdge.East, ref e);
+                    SetupSide("Right_bottom", StandardCursorType.RightSide, WindowEdge.East, ref e);
+                    SetupSide("Top", StandardCursorType.TopSide, WindowEdge.North, ref e);
+                    SetupSide("Bottom", StandardCursorType.BottomSide, WindowEdge.South, ref e);
+                    SetupSide("TopLeft", StandardCursorType.TopLeftCorner, WindowEdge.NorthWest, ref e);
+                    SetupSide("TopRight", StandardCursorType.TopRightCorner, WindowEdge.NorthEast, ref e);
+                    SetupSide("BottomLeft", StandardCursorType.BottomLeftCorner, WindowEdge.SouthWest, ref e);
+                    SetupSide("BottomRight", StandardCursorType.BottomRightCorner, WindowEdge.SouthEast, ref e);
+                }
+                catch (Exception x)
+                {
+
+                }
+
+                GetControl<Button>(e, "MinimizeButton").Click += delegate
+                {
+                    window.WindowState = WindowState.Minimized;
+                };
+                GetControl<Button>(e, "MaximizeButton").Click += delegate
+                {
+                    window.WindowState = window.WindowState == WindowState.Maximized ? WindowState.Normal : WindowState.Maximized;
+                };
+                GetControl<Button>(e, "CloseButton").Click += delegate
+                {
+                    window.Close();
                 };
             }
+            catch (KeyNotFoundException ex)
+            {
 
-            titleBar.PointerPressed += (object sender, PointerPressedEventArgs ep) =>
-            {
-                window.PlatformImpl?.BeginMoveDrag(ep);
-            };
-
-            SetupSide("Left_top", StandardCursorType.LeftSide, WindowEdge.West, ref e);
-            SetupSide("Left_mid", StandardCursorType.LeftSide, WindowEdge.West, ref e);
-            SetupSide("Left_bottom", StandardCursorType.LeftSide, WindowEdge.West, ref e);
-            SetupSide("Right_top", StandardCursorType.RightSide, WindowEdge.East, ref e);
-            SetupSide("Right_mid", StandardCursorType.RightSide, WindowEdge.East, ref e);
-            SetupSide("Right_bottom", StandardCursorType.RightSide, WindowEdge.East, ref e);
-            SetupSide("Top", StandardCursorType.TopSide, WindowEdge.North, ref e);
-            SetupSide("Bottom", StandardCursorType.BottomSide, WindowEdge.South, ref e);
-            SetupSide("TopLeft", StandardCursorType.TopLeftCorner, WindowEdge.NorthWest, ref e);
-            SetupSide("TopRight", StandardCursorType.TopRightCorner, WindowEdge.NorthEast, ref e);
-            SetupSide("BottomLeft", StandardCursorType.BottomLeftCorner, WindowEdge.SouthWest, ref e);
-            SetupSide("BottomRight", StandardCursorType.BottomRightCorner, WindowEdge.SouthEast, ref e);
-
-            GetControl<Button>(e, "MinimizeButton").Click += delegate 
-            {
-                window.WindowState = WindowState.Minimized;
-            };
-            GetControl<Button>(e, "MaximizeButton").Click += delegate
-            {
-                window.WindowState = window.WindowState == WindowState.Maximized ? WindowState.Normal : WindowState.Maximized;
-            };
-            GetControl<Button>(e, "CloseButton").Click += delegate
-            {
-                window.Close();
-            };
+            }
         }
     }
 }

--- a/Avalonia.Ribbon/Styles/RibbonButtonStyle.xaml
+++ b/Avalonia.Ribbon/Styles/RibbonButtonStyle.xaml
@@ -2,19 +2,35 @@
     xmlns="https://github.com/avaloniaui"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:local="clr-namespace:Avalonia.Controls.Ribbon;assembly=Avalonia.Controls.Ribbon">
-    <Design.PreviewWith>
-        <local:RibbonButton IconPath="/Assets/settings.png" Text="Du texte pour un bouton" />
-    </Design.PreviewWith>
+  <!--Design.PreviewWith>
+      <StackPanel Orientation="Horizontal" Spacing="10">
+        <local:RibbonButton Content="Large Ribbon Button">
+          <local:RibbonButton.Icon>
+            <Image Source="/Assets/settings.png" Width="32" Height="32"/>
+          </local:RibbonButton.Icon>
+        </local:RibbonButton>
+        <local:RibbonButton Size="Medium" Content="Medium Ribbon Button">
+          <local:RibbonButton.Icon>
+            <Image Source="/Assets/settings.png" Width="16" Height="16"/>
+          </local:RibbonButton.Icon>
+        </local:RibbonButton>
+        <local:RibbonButton Size="Small" Content="Small Ribbon Button">
+          <local:RibbonButton.Icon>
+            <Image Source="/Assets/settings.png" Width="16" Height="16"/>
+          </local:RibbonButton.Icon>
+        </local:RibbonButton>
+      </StackPanel>
+    </Design.PreviewWith-->
 
-    <Style Selector="local|RibbonButton">
+    <Style Selector="local|RibbonButton[Size=Large]">
         <Setter Property="Template">
-            <ControlTemplate TargetType="local:RibbonButton">
+            <ControlTemplate>
                 <StackPanel Orientation="Vertical">
                     <Button Name="rButton" Command="{TemplateBinding Command}">
                         <Border>
                             <StackPanel>
-                                <Image Source="{TemplateBinding IconPath}" />
-                                <TextBlock Text="{TemplateBinding Text}" />
+                              <ContentPresenter Content="{TemplateBinding LargeIcon}" />
+                              <ContentPresenter Content="{TemplateBinding Content}" Margin="0,3,0,2"/>
                             </StackPanel>
                         </Border>
                     </Button>
@@ -22,12 +38,45 @@
             </ControlTemplate>
         </Setter>
     </Style>
+  <Style Selector="local|RibbonButton[Size=Medium]">
+    <Setter Property="Template">
+      <ControlTemplate>
+        <StackPanel Orientation="Horizontal">
+          <Button
+              Name="rButton"
+              Padding="0"
+              Command="{TemplateBinding Command}">
+            <Border Margin="0">
+              <StackPanel Orientation="Horizontal">
+                <ContentPresenter Content="{TemplateBinding Icon}" />
+                <ContentPresenter Content="{TemplateBinding Content}" />
+              </StackPanel>
+            </Border>
+          </Button>
+        </StackPanel>
+      </ControlTemplate>
+    </Setter>
+  </Style>
+  <Style Selector="local|RibbonButton[Size=Small]">
+    <Setter Property="Template">
+      <ControlTemplate>
+        <Button
+              Name="rButton"
+              Padding="0"
+              Command="{TemplateBinding Command}">
+          <Border Margin="0">
+              <ContentPresenter Content="{TemplateBinding Icon}" />
+          </Border>
+        </Button>
+      </ControlTemplate>
+    </Setter>
+  </Style>
 
     <Style Selector="Button#rButton">
         <Setter Property="Background" Value="Transparent" />
         <Setter Property="BorderBrush" Value="Transparent" />
     </Style>
-    <Style Selector="Button#rButton Image">
+    <Style Selector="local|RibbonButton[Size=Large] /template/ Button#rButton Image">
         <Setter Property="Height" Value="28" />
         <Setter Property="Width" Value="28" />
         <Setter Property="Margin" Value="0 0 0 5" />

--- a/Avalonia.Ribbon/Styles/RibbonComboButtonStyle.xaml
+++ b/Avalonia.Ribbon/Styles/RibbonComboButtonStyle.xaml
@@ -12,17 +12,18 @@
                     BorderBrush="{TemplateBinding BorderBrush}"
                     BorderThickness="1">
                     <Grid RowDefinitions="*,Auto">
-                        <local:RibbonButton Margin="0" IconPath="{TemplateBinding IconPath}" />
+                        <local:RibbonButton Margin="0" LargeIcon="{TemplateBinding LargeIcon}" />
                         <ToggleButton
                             Name="toggle"
                             Grid.Row="1"
                             BorderThickness="0"
                             ClickMode="Press"
                             Focusable="False"
+                            Padding="5,2"
                             IsChecked="{TemplateBinding IsDropDownOpen,
                                                         Mode=TwoWay}">
                             <StackPanel>
-                                <TextBlock Text="{TemplateBinding Text}" />
+                                <ContentPresenter Content="{TemplateBinding Content}" />
                                 <Path
                                     Width="8"
                                     Height="4"
@@ -30,7 +31,7 @@
                                     HorizontalAlignment="Center"
                                     VerticalAlignment="Center"
                                     Data="F1 M 301.14,-189.041L 311.57,-189.041L 306.355,-182.942L 301.14,-189.041 Z"
-                                    Fill="{DynamicResource ThemeForegroundBrush}"
+                                    Fill="{TemplateBinding Foreground}"
                                     Stretch="Uniform" />
                             </StackPanel>
                         </ToggleButton>

--- a/Avalonia.Ribbon/Styles/RibbonControlStyle.xaml
+++ b/Avalonia.Ribbon/Styles/RibbonControlStyle.xaml
@@ -10,7 +10,8 @@
     </Design.PreviewWith>
 
     <Style Selector="local|RibbonControl">
-        <Setter Property="RemainingTabControlHeaderColor" Value="{DynamicResource TitleBarColorBrush}" />
+      <Setter Property="Margin" Value="0,0,0,-4"/>
+      <Setter Property="RemainingTabControlHeaderColor" Value="{DynamicResource TitleBarColorBrush}" />
       <Setter Property="Background" Value="{DynamicResource ActiveRibbonBackgroundColorBrush}" />
         <Setter Property="Template">
             <ControlTemplate>
@@ -44,13 +45,21 @@
                     <ContentPresenter
                         Name="PART_SelectedContentHost"
                         Height="90"
-                        Padding="5,2,5,5"
+                        Padding="5,0"
                         HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
                         VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
                         Background="{TemplateBinding Background}"
                         Content="{TemplateBinding SelectedContent}"
                         ContentTemplate="{TemplateBinding SelectedContentTemplate}">
                     </ContentPresenter>
+                    <Rectangle Height="4">
+                      <Rectangle.Fill>
+                        <LinearGradientBrush StartPoint="0%,0%" EndPoint="0%,100%">
+                          <GradientStop Offset="0" Color="#40000000"/>
+                          <GradientStop Offset="1" Color="#00000000"/>
+                        </LinearGradientBrush>
+                      </Rectangle.Fill>
+                    </Rectangle>
                 </StackPanel>
             </ControlTemplate>
         </Setter>
@@ -59,16 +68,27 @@
     <Style Selector="local|RibbonControl /template/ ToggleButton.RibbonToggleButton">
         <Setter Property="BorderBrush" Value="Transparent"/>
         <Setter Property="BorderThickness" Value="0"/>
+    </Style>
+    <Style Selector="Window[IsActive=True] local|RibbonControl /template/ ToggleButton.RibbonToggleButton">
         <Setter Property="Foreground" Value="White"/>
+    </Style>
+    <Style Selector="Window[IsActive=False] local|RibbonControl /template/ ToggleButton.RibbonToggleButton">
+        <Setter Property="Foreground" Value="#7FFFFFFF"/>
+    </Style>
+    <Style Selector="local|RibbonWindow[IsActive=True] local|RibbonControl /template/ ToggleButton.RibbonToggleButton">
+        <Setter Property="Foreground" Value="White"/>
+    </Style>
+    <Style Selector="local|RibbonWindow[IsActive=False] local|RibbonControl /template/ ToggleButton.RibbonToggleButton">
+        <Setter Property="Foreground" Value="#7FFFFFFF"/>
     </Style>
     <Style Selector="local|RibbonControl /template/ ToggleButton.RibbonToggleButton:not(:pointerover) /template/ ContentPresenter">
       <Setter Property="Background" Value="Transparent"/>
     </Style>
     <Style Selector="local|RibbonControl /template/ ToggleButton.RibbonToggleButton:pointerover /template/ ContentPresenter">
-        <Setter Property="Background" Value="#40FFFFFF"/>
+        <Setter Property="Background" Value="#1A000000"/>
     </Style>
-    <Style Selector="local|RibbonControl /template/ ToggleButton.RibbonToggleButton:checked /template/ ContentPresenter">
-        <Setter Property="Background" Value="#40FFFFFF"/>
+    <Style Selector="local|RibbonControl /template/ ToggleButton#MenuButton:checked /template/ ContentPresenter">
+        <Setter Property="Background" Value="#1A000000"/>
     </Style>
   
     <Style Selector="local|RibbonControl[IsCollapsed=False] /template/ ToggleButton.RibbonToggleButton Path.RibbonExpandCollapsePath">
@@ -159,5 +179,11 @@
         </Border>
       </ControlTemplate>
     </Setter>
+  </Style>
+  <Style Selector="Window[IsActive=False] local|RibbonControl">
+    <Setter Property="RemainingTabControlHeaderColor" Value="{DynamicResource InactiveTitleBarColorBrush}" />
+  </Style>
+  <Style Selector="local|RibbonWindow local|RibbonControl">
+    <Setter Property="RemainingTabControlHeaderColor" Value="{Binding TitleBarColor, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type local:RibbonWindow}}}" />
   </Style>
 </Styles>

--- a/Avalonia.Ribbon/Styles/RibbonSmallButtonStyle.xaml
+++ b/Avalonia.Ribbon/Styles/RibbonSmallButtonStyle.xaml
@@ -5,7 +5,7 @@
     <Style Selector="local|RibbonSmallButton">
         <Setter Property="Template">
             <ControlTemplate>
-                <local:RibbonButton Name="smallbutton" IconPath="{TemplateBinding IconPath}" />
+                <local:RibbonButton Name="smallbutton"/>
             </ControlTemplate>
         </Setter>
     </Style>

--- a/Avalonia.Ribbon/Styles/RibbonStyle.xaml
+++ b/Avalonia.Ribbon/Styles/RibbonStyle.xaml
@@ -4,12 +4,12 @@
     xmlns:local="clr-namespace:Avalonia.Controls.Ribbon;assembly=Avalonia.Controls.Ribbon"
     xmlns:sys="clr-namespace:System;assembly=netstandard">
     <Design.PreviewWith>
-        <local:RibbonControl>
+        <local:Ribbon>
             <local:RibbonTab Header="Home">FileContent</local:RibbonTab>
-        </local:RibbonControl>
+        </local:Ribbon>
     </Design.PreviewWith>
 
-    <Style Selector="local|RibbonControl">
+    <Style Selector="local|Ribbon">
       <Setter Property="Margin" Value="0,0,0,-4"/>
       <Setter Property="RemainingTabControlHeaderColor" Value="{DynamicResource TitleBarColorBrush}" />
       <Setter Property="Background" Value="{DynamicResource ActiveRibbonBackgroundColorBrush}" />
@@ -18,13 +18,26 @@
                 <StackPanel Background="Transparent">
                     <DockPanel Background="{TemplateBinding RemainingTabControlHeaderColor}">
                       <ToggleButton Name="MenuButton" Padding="16,0" FontWeight="SemiBold" Classes="RibbonToggleButton" VerticalAlignment="Stretch" DockPanel.Dock="Left" IsChecked="{Binding IsMenuOpen, RelativeSource={RelativeSource Mode=TemplatedParent}, Mode=TwoWay}" Content="File"/>
-                      <Popup PlacementTarget="{Binding Source=MenuButton}" PlacementMode="Bottom" StaysOpen="False" IsOpen="{Binding IsMenuOpen, RelativeSource={RelativeSource Mode=TemplatedParent}, Mode=TwoWay}" Width="500" MinHeight="300">
+                      <Popup PlacementTarget="{Binding Source=MenuButton}" PlacementMode="Bottom" VerticalOffset="-34" StaysOpen="False" IsOpen="{Binding IsMenuOpen, RelativeSource={RelativeSource Mode=TemplatedParent}, Mode=TwoWay}" Width="500" MinHeight="300">
                         <DockPanel>
                           <DockPanel Name="MenuRightColumnDockPanel" Width="200" DockPanel.Dock="Right">
-                              <TextBlock Text="Places" FontWeight="Bold" Margin="10,5" DockPanel.Dock="Top"/>
-                              <ListBox Classes="RibbonMenuPlacesList" Items="{Binding MenuPlacesItems, RelativeSource={RelativeSource Mode=TemplatedParent}}"/>
+                            <Grid Height="34" DockPanel.Dock="Top">
+                              <TextBlock Text="Places" FontWeight="SemiBold" Margin="10,0" VerticalAlignment="Center"/>
+                            </Grid>
+                            <ListBox Classes="RibbonMenuPlacesList" Items="{Binding MenuPlacesItems, RelativeSource={RelativeSource Mode=TemplatedParent}}"/>
                           </DockPanel>
-                          <Menu Classes="RibbonMenuMenu" Items="{Binding MenuItems, RelativeSource={RelativeSource Mode=TemplatedParent}}"/>
+                          <Grid>
+                            <Menu Classes="RibbonMenuMenu" Items="{Binding MenuItems, RelativeSource={RelativeSource Mode=TemplatedParent}}" Padding="0,34,0,0"/>
+                            <ToggleButton Name="BackButton" FontWeight="SemiBold" Classes="RibbonToggleButton" IsChecked="{Binding IsChecked, ElementName=MenuButton, Mode=TwoWay}" HorizontalAlignment="Left" VerticalAlignment="Top" Height="34" Width="{Binding Bounds.Width, ElementName=MenuButton, Mode=OneWay}">
+                              <Grid Width="24" Height="24">
+                                <Ellipse Stroke="{Binding Foreground, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=ToggleButton}}" StrokeThickness="1"/>
+                                <Grid Width="14" Height="10">
+                                  <Rectangle Fill="{Binding Foreground, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=ToggleButton}}" Height="1" VerticalAlignment="Center"/>
+                                  <Path Data="M 5 0 L 0 5 L 5 10" Stroke="{Binding Foreground, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=ToggleButton}}" StrokeThickness="1" HorizontalAlignment="Left"/>
+                                </Grid>
+                              </Grid>
+                            </ToggleButton>
+                          </Grid>
                         </DockPanel>
                       </Popup>
                       <ToggleButton Classes="RibbonToggleButton" VerticalAlignment="Stretch" DockPanel.Dock="Right" Width="{Binding Bounds.Height, RelativeSource={RelativeSource Mode=Self}}" IsChecked="{Binding IsCollapsed, RelativeSource={RelativeSource Mode=TemplatedParent}, Mode=TwoWay}">
@@ -65,65 +78,64 @@
         </Setter>
     </Style>
 
-    <Style Selector="local|RibbonControl /template/ ToggleButton.RibbonToggleButton">
+    <Style Selector="local|Ribbon /template/ ToggleButton.RibbonToggleButton">
         <Setter Property="BorderBrush" Value="Transparent"/>
         <Setter Property="BorderThickness" Value="0"/>
     </Style>
-    <Style Selector="Window[IsActive=True] local|RibbonControl /template/ ToggleButton.RibbonToggleButton">
+    <Style Selector="Window[IsActive=True] local|Ribbon /template/ ToggleButton.RibbonToggleButton">
         <Setter Property="Foreground" Value="White"/>
     </Style>
-    <Style Selector="Window[IsActive=False] local|RibbonControl /template/ ToggleButton.RibbonToggleButton">
+    <Style Selector="Window[IsActive=False] local|Ribbon /template/ ToggleButton.RibbonToggleButton">
         <Setter Property="Foreground" Value="#7FFFFFFF"/>
     </Style>
-    <Style Selector="local|RibbonWindow[IsActive=True] local|RibbonControl /template/ ToggleButton.RibbonToggleButton">
+    <Style Selector="local|RibbonWindow[IsActive=True] local|Ribbon /template/ ToggleButton.RibbonToggleButton">
         <Setter Property="Foreground" Value="White"/>
     </Style>
-    <Style Selector="local|RibbonWindow[IsActive=False] local|RibbonControl /template/ ToggleButton.RibbonToggleButton">
+    <Style Selector="local|RibbonWindow[IsActive=False] local|Ribbon /template/ ToggleButton.RibbonToggleButton">
         <Setter Property="Foreground" Value="#7FFFFFFF"/>
     </Style>
-    <Style Selector="local|RibbonControl /template/ ToggleButton.RibbonToggleButton:not(:pointerover) /template/ ContentPresenter">
+    <Style Selector="local|Ribbon /template/ ToggleButton.RibbonToggleButton:not(:pointerover) /template/ ContentPresenter">
       <Setter Property="Background" Value="Transparent"/>
     </Style>
-    <Style Selector="local|RibbonControl /template/ ToggleButton.RibbonToggleButton:pointerover /template/ ContentPresenter">
+    <Style Selector="local|Ribbon /template/ ToggleButton.RibbonToggleButton:pointerover /template/ ContentPresenter">
         <Setter Property="Background" Value="#1A000000"/>
     </Style>
-    <Style Selector="local|RibbonControl /template/ ToggleButton#MenuButton:checked /template/ ContentPresenter">
+    <Style Selector="local|Ribbon /template/ ToggleButton#MenuButton:checked /template/ ContentPresenter">
+        <Setter Property="Background" Value="#1A000000"/>
+    </Style>
+  <Style Selector="local|Ribbon /template/ ToggleButton#BackButton:checked /template/ ContentPresenter">
         <Setter Property="Background" Value="#1A000000"/>
     </Style>
   
-    <Style Selector="local|RibbonControl[IsCollapsed=False] /template/ ToggleButton.RibbonToggleButton Path.RibbonExpandCollapsePath">
+    <Style Selector="local|Ribbon[IsCollapsed=False] /template/ ToggleButton.RibbonToggleButton Path.RibbonExpandCollapsePath">
         <Setter Property="Data" Value="M 0 6 L 5 0 L 10 6"/>
     </Style>
-    <Style Selector="local|RibbonControl[IsCollapsed=True] /template/ ToggleButton.RibbonToggleButton Path.RibbonExpandCollapsePath">
+    <Style Selector="local|Ribbon[IsCollapsed=True] /template/ ToggleButton.RibbonToggleButton Path.RibbonExpandCollapsePath">
       <Setter Property="Data" Value="M 0 0 L 5 6 L 10 0"/>
     </Style>
   
-    <Style Selector="local|RibbonControl[IsCollapsed=True] /template/ ContentPresenter">
+    <Style Selector="local|Ribbon[IsCollapsed=True] /template/ ContentPresenter">
         <Setter Property="IsVisible" Value="false"/>
     </Style>
-    <Style Selector="local|RibbonControl WrapPanel">
-        <Setter Property="Background" Value="{Binding $parent[local:RibbonControl].RemainingTabControlHeaderColor}" />
+    <Style Selector="local|Ribbon WrapPanel">
+        <Setter Property="Background" Value="{Binding $parent[local:Ribbon].RemainingTabControlHeaderColor}" />
     </Style>
 
-    <Style Selector="local|RibbonControl /template/ Popup Menu.RibbonMenuMenu">
+    <Style Selector="local|Ribbon /template/ Popup Menu.RibbonMenuMenu">
+      <Setter Property="Background" Value="{DynamicResource TitleBarColorBrush}"/>
+      <Setter Property="Foreground" Value="White"/>
       <Setter Property="ItemsPanel">
         <ItemsPanelTemplate>
           <StackPanel Orientation="Vertical"/>
         </ItemsPanelTemplate>
       </Setter>
     </Style>
-  <Style Selector="local|RibbonControl /template/ Popup ListBox.RibbonMenuPlacesList">
-    <Setter Property="BorderThickness" Value="1,0,0,0"/>
-  </Style>
-  <Style Selector="local|RibbonControl /template/ Popup ListBox.RibbonMenuPlacesList ListBoxItem">
-      <Setter Property="Padding" Value="10"/>
-  </Style>
-  <Style Selector="local|RibbonControl /template/ Popup Menu.RibbonMenuMenu > MenuItem MenuItem">
-      <Setter Property="Padding" Value="10"/>
-  </Style>
-  <Style Selector="local|RibbonControl /template/ Popup Menu.RibbonMenuMenu > MenuItem">
-      <Setter Property="Padding" Value="10"/>
-      <Setter Property="Template">
+  <!--Style Selector="local|Ribbon /template/ Popup Menu.RibbonMenuMenu[IsOpen=True]">
+    <Setter Property="Margin" Value="0,0,-200,0"/>
+  </Style-->
+  <Style Selector="local|Ribbon /template/ Popup Menu.RibbonMenuMenu > MenuItem">
+    <Setter Property="Padding" Value="10"/>
+    <Setter Property="Template">
       <ControlTemplate>
         <Border Name="root"
                 Background="{TemplateBinding Background}"
@@ -156,34 +168,51 @@
             </ContentPresenter>
             <Path Name="rightArrow"
                   Data="M0,0L4,3.5 0,7z"
-                  Fill="{DynamicResource ThemeForegroundBrush}"
+                  Fill="{TemplateBinding Foreground}"
                   Margin="10,0,0,0"
                   VerticalAlignment="Center"
                   Grid.Column="3"/>
-            <Popup Name="PART_Popup"
-                   Width="200"
-                   PlacementMode="Right"
-                   StaysOpen="False"
+            <Popup Name="PART_Popup" Width="200" PlacementMode="Left" StaysOpen="False"
                    IsOpen="{TemplateBinding IsSubMenuOpen, Mode=TwoWay}">
-              <Border Background="{TemplateBinding Background}">
-                <ScrollViewer>                  
-                    <ItemsPresenter Name="PART_ItemsPresenter"
-                                    Items="{TemplateBinding Items}"
-                                    ItemsPanel="{TemplateBinding ItemsPanel}"
-                                    ItemTemplate="{TemplateBinding ItemTemplate}"
-                                    Margin="4 2"/>                                      
+              <Border Background="#FFF9F9F9">
+                <ScrollViewer>
+                  <ItemsPresenter Name="PART_ItemsPresenter"
+                                  Items="{TemplateBinding Items}"
+                                  ItemsPanel="{TemplateBinding ItemsPanel}"
+                                  ItemTemplate="{TemplateBinding ItemTemplate}"
+                                  Margin="4 2"/>
                 </ScrollViewer>
               </Border>
             </Popup>
-            </Grid>
+          </Grid>
         </Border>
       </ControlTemplate>
     </Setter>
   </Style>
-  <Style Selector="Window[IsActive=False] local|RibbonControl">
+  <!--Style Selector="local|Ribbon /template/ Popup Menu.RibbonMenuMenu > MenuItem[IsSubMenuOpen=False]">
+    <Setter Property="Margin" Value="0,0,200,0"/>
+  </Style-->
+  <Style Selector="local|Ribbon /template/ Popup Menu.RibbonMenuMenu > MenuItem[IsPointerOver=True]">
+    <Setter Property="IsSubMenuOpen" Value="True"/>
+  </Style>
+  <Style Selector="local|Ribbon /template/ Popup Menu.RibbonMenuMenu > MenuItem[IsPointerOver=False]">
+    <Setter Property="IsSubMenuOpen" Value="False"/>
+  </Style>
+  <Style Selector="local|Ribbon /template/ Popup Menu.RibbonMenuMenu > MenuItem MenuItem">
+    <Setter Property="Foreground" Value="Black"/>
+    <Setter Property="Padding" Value="10"/>
+  </Style>
+  <Style Selector="local|Ribbon /template/ Popup ListBox.RibbonMenuPlacesList">
+    <Setter Property="BorderThickness" Value="0"/>
+    <Setter Property="Background" Value="#FFF9F9F9"/>
+  </Style>
+  <Style Selector="local|Ribbon /template/ Popup ListBox.RibbonMenuPlacesList ListBoxItem">
+    <Setter Property="Padding" Value="10"/>
+  </Style>
+  <Style Selector="Window[IsActive=False] local|Ribbon">
     <Setter Property="RemainingTabControlHeaderColor" Value="{DynamicResource InactiveTitleBarColorBrush}" />
   </Style>
-  <Style Selector="local|RibbonWindow local|RibbonControl">
+  <Style Selector="local|RibbonWindow local|Ribbon">
     <Setter Property="RemainingTabControlHeaderColor" Value="{Binding TitleBarColor, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type local:RibbonWindow}}}" />
   </Style>
 </Styles>

--- a/Avalonia.Ribbon/Styles/RibbonStyle.xaml
+++ b/Avalonia.Ribbon/Styles/RibbonStyle.xaml
@@ -103,7 +103,7 @@
     <Style Selector="local|Ribbon /template/ ToggleButton#MenuButton:checked /template/ ContentPresenter">
         <Setter Property="Background" Value="#1A000000"/>
     </Style>
-  <Style Selector="local|Ribbon /template/ ToggleButton#BackButton:checked /template/ ContentPresenter">
+    <Style Selector="local|Ribbon /template/ ToggleButton#BackButton:not(:checked) /template/ ContentPresenter">
         <Setter Property="Background" Value="#1A000000"/>
     </Style>
   

--- a/Avalonia.Ribbon/Styles/RibbonStyles.xaml
+++ b/Avalonia.Ribbon/Styles/RibbonStyles.xaml
@@ -1,7 +1,7 @@
 ﻿<Styles xmlns="https://github.com/avaloniaui" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <StyleInclude Source="/Styles/RibbonThemeColor.xaml" />
 
-    <StyleInclude Source="/Styles/RibbonControlStyle.xaml" />
+    <StyleInclude Source="/Styles/RibbonStyle.xaml" />
     <StyleInclude Source="/Styles/RibbonTabStyle.xaml" />
     <StyleInclude Source="/Styles/RibbonWindowStyle.xaml" />
     <StyleInclude Source="/Styles/RibbonButtonStyle.xaml" />

--- a/Avalonia.Ribbon/Styles/RibbonTabGroupStyle.xaml
+++ b/Avalonia.Ribbon/Styles/RibbonTabGroupStyle.xaml
@@ -7,12 +7,13 @@
     </Design.PreviewWith>
 
     <Style Selector="local|RibbonTabGroup">
+        <Setter Property="Padding" Value="0,2"/>
         <Setter Property="Template">
             <ControlTemplate TargetType="local:RibbonTabGroup">
                 <DockPanel>
                     <Border
                         Width="1"
-                        Margin="5,0,5,0"
+                        Margin="5"
                         Background="{DynamicResource HoveredBorderBackgroundColorBrush}"
                         DockPanel.Dock="Right" />
                     <Grid
@@ -20,7 +21,7 @@
                         DockPanel.Dock="Left"
                         RowDefinitions="72,16">
 
-                        <ContentControl Grid.Row="0" Content="{TemplateBinding Content}" />
+                        <ContentPresenter Grid.Row="0" Content="{TemplateBinding Content}" Margin="{TemplateBinding Padding}" />
 
                         <Grid
                             Grid.Row="1"
@@ -40,10 +41,15 @@
                                 Height="15"
                                 Command="{TemplateBinding Command}">
                                 <Border>
-                                    <Image
+                                  <Grid Width="9" Height="9">
+                                    <Border BorderBrush="#FF7F7F7F" BorderThickness="1,1,0,0"/>
+                                    <Line StartPoint="0,0" EndPoint="6,6" HorizontalAlignment="Right" VerticalAlignment="Bottom" Stroke="#FF7F7F7F" StrokeThickness="1"/>
+                                    <Border BorderBrush="#FF7F7F7F" BorderThickness="0,0,1,1" Width="4" Height="4" HorizontalAlignment="Right" VerticalAlignment="Bottom"/>
+                                  </Grid>
+                                  <!--Image
                                         Width="10"
                                         Height="10"
-                                        Source="avares://Avalonia.Controls.Ribbon/Assets/corner.png" />
+                                        Source="avares://Avalonia.Controls.Ribbon/Assets/corner.png" /-->
                                 </Border>
                             </Button>
                         </Grid>

--- a/Avalonia.Ribbon/Styles/RibbonTabGroupStyle.xaml
+++ b/Avalonia.Ribbon/Styles/RibbonTabGroupStyle.xaml
@@ -21,7 +21,8 @@
                         DockPanel.Dock="Left"
                         RowDefinitions="72,16">
 
-                        <ContentPresenter Grid.Row="0" Content="{TemplateBinding Content}" Margin="{TemplateBinding Padding}" />
+                        <ItemsPresenter Grid.Row="0" Items="{TemplateBinding Items}" ItemsPanel="{TemplateBinding ItemsPanel}" ItemTemplate="{TemplateBinding ItemTemplate}" Margin="{TemplateBinding Padding}" />
+                      <!--ItemContainerGenerator="{TemplateBinding ItemContainerGenerator}"-->
 
                         <Grid
                             Grid.Row="1"
@@ -46,10 +47,6 @@
                                     <Line StartPoint="0,0" EndPoint="6,6" HorizontalAlignment="Right" VerticalAlignment="Bottom" Stroke="#FF7F7F7F" StrokeThickness="1"/>
                                     <Border BorderBrush="#FF7F7F7F" BorderThickness="0,0,1,1" Width="4" Height="4" HorizontalAlignment="Right" VerticalAlignment="Bottom"/>
                                   </Grid>
-                                  <!--Image
-                                        Width="10"
-                                        Height="10"
-                                        Source="avares://Avalonia.Controls.Ribbon/Assets/corner.png" /-->
                                 </Border>
                             </Button>
                         </Grid>
@@ -58,6 +55,11 @@
                 </DockPanel>
             </ControlTemplate>
         </Setter>
+      <Setter Property="ItemsPanel">
+        <ItemsPanelTemplate>
+          <StackPanel Orientation="Horizontal"/>
+        </ItemsPanelTemplate>
+      </Setter>
     </Style>
 
     <Style Selector="Button#rButton">

--- a/Avalonia.Ribbon/Styles/RibbonTabStyle.xaml
+++ b/Avalonia.Ribbon/Styles/RibbonTabStyle.xaml
@@ -31,23 +31,21 @@
             </ControlTemplate>
         </Setter>
     </Style>
-    <Style Selector="Window[IsActive=False] local|RibbonControl local|RibbonTab:not(:selected)">
+    <Style Selector="Window[IsActive=False] local|Ribbon local|RibbonTab:not(:selected)">
         <Setter Property="Foreground" Value="#7FFFFFFF"/>
     </Style>
-    <Style Selector="local|RibbonWindow[IsActive=False] local|RibbonControl local|RibbonTab:not(:selected)">
+    <Style Selector="local|RibbonWindow[IsActive=False] local|Ribbon local|RibbonTab:not(:selected)">
         <Setter Property="Foreground" Value="#7FFFFFFF"/>
     </Style>
-  <Style Selector="Window[IsActive=False] local|RibbonControl[IsCollapsed=True] local|RibbonTab:selected">
+  <Style Selector="Window[IsActive=False] local|Ribbon[IsCollapsed=True] local|RibbonTab:selected">
     <Setter Property="Foreground" Value="#7FFFFFFF"/>
   </Style>
-  <Style Selector="local|RibbonWindow[IsActive=False] local|RibbonControl[IsCollapsed=True] local|RibbonTab:selected">
+  <Style Selector="local|RibbonWindow[IsActive=False] local|Ribbon[IsCollapsed=True] local|RibbonTab:selected">
     <Setter Property="Foreground" Value="#7FFFFFFF"/>
   </Style>
 
-    <Style Selector="local|RibbonControl[IsCollapsed=False] local|RibbonTab:selected">
+    <Style Selector="local|Ribbon[IsCollapsed=False] local|RibbonTab:selected">
         <Setter Property="Foreground" Value="{DynamicResource TitleBarColorBrush}" />
-        <Setter Property="Margin" Value="0 0 0 0" />
-        <Setter Property="Padding" Value="10 0" />
         <Setter Property="Background" Value="{Binding $parent.Background}" />
     </Style>
 </Styles>

--- a/Avalonia.Ribbon/Styles/RibbonTabStyle.xaml
+++ b/Avalonia.Ribbon/Styles/RibbonTabStyle.xaml
@@ -10,7 +10,7 @@
         <Setter Property="FontSize" Value="12" />
         <Setter Property="Height" Value="34" />
         <Setter Property="VerticalContentAlignment" Value="Center" />
-        <Setter Property="Background" Value="{DynamicResource TitleBarColorBrush}" />
+        <Setter Property="Background" Value="Transparent" />
         <Setter Property="Foreground" Value="{DynamicResource ActiveRibbonBackgroundColorBrush}" />
         <Setter Property="Margin" Value="0 0 0 0" />
         <Setter Property="Padding" Value="10 0" />
@@ -31,12 +31,23 @@
             </ControlTemplate>
         </Setter>
     </Style>
+    <Style Selector="Window[IsActive=False] local|RibbonControl local|RibbonTab:not(:selected)">
+        <Setter Property="Foreground" Value="#7FFFFFFF"/>
+    </Style>
+    <Style Selector="local|RibbonWindow[IsActive=False] local|RibbonControl local|RibbonTab:not(:selected)">
+        <Setter Property="Foreground" Value="#7FFFFFFF"/>
+    </Style>
+  <Style Selector="Window[IsActive=False] local|RibbonControl[IsCollapsed=True] local|RibbonTab:selected">
+    <Setter Property="Foreground" Value="#7FFFFFFF"/>
+  </Style>
+  <Style Selector="local|RibbonWindow[IsActive=False] local|RibbonControl[IsCollapsed=True] local|RibbonTab:selected">
+    <Setter Property="Foreground" Value="#7FFFFFFF"/>
+  </Style>
 
-    <Style Selector="local|RibbonTab:selected">
+    <Style Selector="local|RibbonControl[IsCollapsed=False] local|RibbonTab:selected">
         <Setter Property="Foreground" Value="{DynamicResource TitleBarColorBrush}" />
         <Setter Property="Margin" Value="0 0 0 0" />
         <Setter Property="Padding" Value="10 0" />
         <Setter Property="Background" Value="{Binding $parent.Background}" />
     </Style>
-
 </Styles>

--- a/Avalonia.Ribbon/Styles/RibbonThemeColor.xaml
+++ b/Avalonia.Ribbon/Styles/RibbonThemeColor.xaml
@@ -5,6 +5,7 @@
         <Color x:Key="ClickedBackgroundColor">#a4a4a4</Color>
         <Color x:Key="ClickedBorderBackgroundColor">#939393</Color>
         <Color x:Key="TitleBarColor">#2b579a</Color>
+        <Color x:Key="InactiveTitleBarColor">#466799</Color>
         <Color x:Key="ActiveRibbonBackgroundColor">#f0f0f0</Color>
 
         <SolidColorBrush x:Key="HoveredBackgroundColorBrush" Color="{DynamicResource HoveredBackgroundColor}" />
@@ -12,6 +13,7 @@
         <SolidColorBrush x:Key="ClickedBackgroundColorBrush" Color="{DynamicResource ClickedBackgroundColor}" />
         <SolidColorBrush x:Key="ClickedBorderBackgroundColorBrush" Color="{DynamicResource ClickedBorderBackgroundColor}" />
         <SolidColorBrush x:Key="TitleBarColorBrush" Color="{DynamicResource TitleBarColor}" />
+        <SolidColorBrush x:Key="InactiveTitleBarColorBrush" Color="{DynamicResource InactiveTitleBarColor}" />
         <SolidColorBrush x:Key="ActiveRibbonBackgroundColorBrush" Color="{DynamicResource ActiveRibbonBackgroundColor}" />
     </Style.Resources>
 </Style>

--- a/Avalonia.Ribbon/Styles/RibbonWindowStyle.xaml
+++ b/Avalonia.Ribbon/Styles/RibbonWindowStyle.xaml
@@ -2,142 +2,178 @@
     xmlns="https://github.com/avaloniaui"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:local="clr-namespace:Avalonia.Controls.Ribbon;assembly=Avalonia.Controls.Ribbon">
-
-    <Style Selector="local|RibbonWindow">
-        <Setter Property="TitleBarColor" Value="{DynamicResource TitleBarColorBrush}" />
-        <Setter Property="Template">
-            <ControlTemplate>
-                <Grid
-                    Name="OuterGrid"
-                    ColumnDefinitions="8,*,8"
-                    RowDefinitions="4,64,86,*,8">
-                    <DockPanel
-                        Grid.Row="1"
-                        Grid.RowSpan="3"
-                        Grid.Column="0"
-                        Grid.ColumnSpan="3">
-                        <Grid
-                            Name="TitleBar"
-                            Height="31"
-                            Background="{TemplateBinding TitleBarColor}"
-                            ColumnDefinitions="Auto,*,Auto"
-                            DockPanel.Dock="Top">
-                            <TextBlock
-                                Margin="5,0,0,0"
-                                VerticalAlignment="Center"
-                                Foreground="White">
-                                Title
-                            </TextBlock>
-                            <StackPanel
-                                Grid.Column="2"
-                                Margin="0,0,8,0"
-                                Orientation="Horizontal">
-                                <StackPanel.Styles>
-                                    <Style Selector="Button">
-                                        <Setter Property="BorderThickness" Value="0" />
-                                        <Setter Property="Background" Value="Transparent" />
-                                        <Setter Property="Width" Value="45" />
-                                    </Style>
-                                    <Style Selector="Button:pointerover">
-                                        <Setter Property="Background" Value="#124078" />
-                                    </Style>
-                                    <Style Selector="Button#CloseButton:pointerover">
-                                        <Setter Property="Background" Value="red" />
-                                    </Style>
-                                </StackPanel.Styles>
-                                <Button Name="MinimizeButton">
-                                    <Image Height="22" Source="avares://Avalonia.Controls.Ribbon/Assets/minimize.png" />
-                                </Button>
-                                <Button Name="MaximizeButton">
-                                    <Image
-                                        Name="ImageMaximizeButton"
-                                        Height="22"
-                                        Source="avares://Avalonia.Controls.Ribbon/Assets/maximize.png" />
-                                </Button>
-                                <Button Name="CloseButton">
-                                    <Image Height="25" Source="avares://Avalonia.Controls.Ribbon/Assets/close.png" />
-                                </Button>
-                            </StackPanel>
+  <Style Selector="local|RibbonWindow">
+    <Setter Property="BorderBrush" Value="{DynamicResource TitleBarColorBrush}"/>
+    <Setter Property="TitleBarColor" Value="{DynamicResource TitleBarColorBrush}" />
+    <Setter Property="Template">
+      <ControlTemplate>
+        <Grid>
+          <Border Classes="OuterBorder">
+            <DockPanel>
+              <Grid
+                Name="TitleBar"
+                Height="30"
+                Background="{TemplateBinding TitleBarColor}"
+                ColumnDefinitions="Auto,*,Auto"
+                DockPanel.Dock="Top">
+                <TextBlock
+                    Margin="5,0,0,0"
+                    VerticalAlignment="Center"
+                    Foreground="White">
+                  Title
+                </TextBlock>
+                <StackPanel
+                    Grid.Column="2"
+                    Orientation="Horizontal">
+                  <StackPanel.Styles>
+                    <Style Selector="Button">
+                      <Setter Property="BorderThickness" Value="0" />
+                      <Setter Property="Background" Value="Transparent" />
+                      <Setter Property="Width" Value="45" />
+                      <Setter Property="Height" Value="30" />
+                      <Setter Property="VerticalAlignment" Value="Top"/>
+                      <Setter Property="Foreground" Value="White"/>
+                    </Style>
+                    <Style Selector="Button > Path">
+                      <Setter Property="Stroke" Value="{Binding Foreground, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=Button}}"/>
+                      <Setter Property="StrokeThickness" Value="1"/>
+                    </Style>
+                    <Style Selector="Button:pointerover">
+                      <Setter Property="Background" Value="#1A000000" />
+                    </Style>
+                    <Style Selector="Button:pressed">
+                      <Setter Property="Background" Value="#36000000" />
+                    </Style>
+                    <Style Selector="Button:Disabled">
+                      <Setter Property="Foreground" Value="#33FFFFFF" />
+                    </Style>
+                    <Style Selector="Button#MinimizeButton > Rectangle">
+                      <Setter Property="Fill" Value="{Binding Foreground, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=Button}}"/>
+                    </Style>
+                    <Style Selector="Button#MaximizeButton Rectangle">
+                      <Setter Property="Stroke" Value="{Binding Foreground, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=Button}}"/>
+                      <Setter Property="StrokeThickness" Value="1"/>
+                    </Style>
+                    <Style Selector="Button#MaximizeButton > Grid > Grid Border">
+                      <Setter Property="BorderBrush" Value="{Binding Foreground, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=Button}}"/>
+                    </Style>
+                    <Style Selector="local|RibbonWindow[WindowState=Maximized] /template/ Button#MaximizeButton > Grid > Rectangle">
+                      <Setter Property="IsVisible" Value="False"/>
+                    </Style>
+                    <Style Selector="local|RibbonWindow[WindowState=Normal] /template/ Button#MaximizeButton > Grid > Grid">
+                      <Setter Property="IsVisible" Value="False"/>
+                    </Style>
+                    <Style Selector="local|RibbonWindow[WindowState=Minimized] /template/ Button#MaximizeButton > Grid > Grid">
+                      <Setter Property="IsVisible" Value="False"/>
+                    </Style>
+                    <Style Selector="Button#MaximizeButton > Grid > Grid > Rectangle">
+                      <Setter Property="Stroke" Value="Transparent"/>
+                      <Setter Property="StrokeThickness" Value="0"/>
+                      <Setter Property="Fill" Value="{Binding Foreground, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=Button}}"/>
+                    </Style>
+                    <Style Selector="Button#CloseButton:pointerover">
+                      <Setter Property="Background" Value="#FFE81123" />
+                    </Style>
+                    <Style Selector="Button#CloseButton:pressed">
+                      <Setter Property="Background" Value="#99E71022" />
+                    </Style>
+                    <Style Selector="local|RibbonWindow[IsActive=false] /template/ Button:not(:pointerover):not(:pressed)">
+                      <Setter Property="Opacity" Value="0.5"/>
+                    </Style>
+                  </StackPanel.Styles>
+                  <Button Name="MinimizeButton">
+                    <Rectangle Width="10" Height="1"/>
+                  </Button>
+                  <Button Name="MaximizeButton">
+                    <Grid>
+                      <Rectangle Width="10" Height="10"/>
+                      <Grid Width="10" Height="10">
+                        <Border BorderThickness="1" Width="8" Height="8" HorizontalAlignment="Left" VerticalAlignment="Bottom"/>
+                        <Grid Width="8" Height="8" HorizontalAlignment="Right" VerticalAlignment="Top">
+                          <Border BorderThickness="0,1,1,0"/>
+                          <Rectangle HorizontalAlignment="Left" VerticalAlignment="Top" Width="1" Height="3"/>
+                          <Rectangle HorizontalAlignment="Right" VerticalAlignment="Bottom" Width="3" Height="1"/>
                         </Grid>
-                        <ItemsPresenter Items="{TemplateBinding Items}" />
-                    </DockPanel>
-                    <Border
-                        Name="TopLeft"
-                        Background="{TemplateBinding TitleBarColor}"
-                        BorderBrush="{DynamicResource TitleBarColorBrush}"
-                        BorderThickness="1,1,0,0" />
-                    <Border
-                        Name="TopRight"
-                        Grid.Column="2"
-                        Background="{TemplateBinding TitleBarColor}"
-                        BorderBrush="{DynamicResource TitleBarColorBrush}"
-                        BorderThickness="0,1,1,0" />
-                    <Border
-                        Name="BottomLeft"
-                        Grid.Row="4"
-                        Background="Transparent"
-                        BorderBrush="{DynamicResource TitleBarColorBrush}"
-                        BorderThickness="1,0,0,1" />
-                    <Border
-                        Name="BottomRight"
-                        Grid.Row="4"
-                        Grid.Column="2"
-                        Background="Transparent"
-                        BorderBrush="{DynamicResource TitleBarColorBrush}"
-                        BorderThickness="0,0,1,1" />
-                    <Border
-                        Name="Top"
-                        Grid.Column="1"
-                        Background="{TemplateBinding TitleBarColor}" />
-                    <Border
-                        Name="Right_top"
-                        Grid.Row="1"
-                        Grid.Column="2"
-                        Background="Transparent"
-                        BorderBrush="{DynamicResource TitleBarColorBrush}"
-                        BorderThickness="0,0,1,0" />
-                    <Border
-                        Name="Right_mid"
-                        Grid.Row="2"
-                        Grid.Column="2"
-                        Background="Transparent"
-                        BorderBrush="{DynamicResource TitleBarColorBrush}"
-                        BorderThickness="0,0,1,0" />
-                    <Border
-                        Name="Right_bottom"
-                        Grid.Row="3"
-                        Grid.Column="2"
-                        Background="Transparent"
-                        BorderBrush="{DynamicResource TitleBarColorBrush}"
-                        BorderThickness="0,0,1,0" />
-                    <Border
-                        Name="Bottom"
-                        Grid.Row="4"
-                        Grid.Column="1"
-                        Background="Transparent"
-                        BorderBrush="{DynamicResource TitleBarColorBrush}"
-                        BorderThickness="0,0,0,1" />
-                    <Border
-                        Name="Left_top"
-                        Grid.Row="1"
-                        Background="Transparent"
-                        BorderBrush="{DynamicResource TitleBarColorBrush}"
-                        BorderThickness="1,0,0,0" />
-                    <Border
-                        Name="Left_mid"
-                        Grid.Row="2"
-                        Background="Transparent"
-                        BorderBrush="{DynamicResource TitleBarColorBrush}"
-                        BorderThickness="1,0,0,0" />
-                    <Border
-                        Name="Left_bottom"
-                        Grid.Row="3"
-                        Background="Transparent"
-                        BorderBrush="{DynamicResource TitleBarColorBrush}"
-                        BorderThickness="1,0,0,0" />
-                </Grid>
-            </ControlTemplate>
-        </Setter>
-    </Style>
-
+                      </Grid>
+                    </Grid>
+                  </Button>
+                  <Button Name="CloseButton">
+                    <Path Data="M 0 0 L 10 10 M 10 0 L 0 10"/>
+                  </Button>
+                </StackPanel>
+              </Grid>
+              <ContentPresenter Content="{TemplateBinding Content}" ContentTemplate="{TemplateBinding ContentTemplate}" Background="{TemplateBinding Background}"/>
+            </DockPanel>
+          </Border>
+          <Grid Name="ResizeGrid" ColumnDefinitions="8,*,8" RowDefinitions="8,*,8">
+            <Border Name="TopLeft"/>
+            <Border
+                Name="TopRight"
+                Grid.Column="2"/>
+            <Border
+                Name="BottomLeft"
+                Grid.Row="2"/>
+            <Border
+                Name="BottomRight"
+                Grid.Row="2"
+                Grid.Column="2"/>
+            <Border
+                Name="Top"
+                Grid.Column="1"/>
+            <Border
+                Name="Right_top"
+                Grid.Row="0"
+                Grid.Column="2"/>
+            <Border
+                Name="Right_mid"
+                Grid.Row="0"
+                Grid.Column="2"/>
+            <Border
+                Name="Right_bottom"
+                Grid.Row="1"
+                Grid.Column="2"/>
+            <Border
+                Name="Bottom"
+                Grid.Row="2"
+                Grid.Column="1"/>
+            <Border
+                Name="Left_top"
+                Grid.Row="0"/>
+            <Border
+                Name="Left_mid"
+                Grid.Row="0"/>
+            <Border
+                Name="Left_bottom"
+                Grid.Row="1"/>
+          </Grid>
+        </Grid>
+      </ControlTemplate>
+    </Setter>
+  </Style>
+  <Style Selector="local|RibbonWindow[HasSystemDecorations=False] /template/ Border.OuterBorder">
+    <Setter Property="BorderBrush" Value="{TemplateBinding BorderBrush}"/>
+    <Setter Property="BorderThickness" Value="1"/>
+  </Style>
+  <Style Selector="local|RibbonWindow[WindowState=Maximized] /template/ Border.OuterBorder">
+    <Setter Property="BorderThickness" Value="0"/>
+  </Style>
+  <Style Selector="local|RibbonWindow[HasSystemDecorations=True] /template/ Grid#TitleBar">
+    <Setter Property="IsVisible" Value="False"/>
+  </Style>
+  <Style Selector="local|RibbonWindow /template/ Grid#ResizeGrid Border">
+    <Setter Property="Background" Value="#01000000"/>
+  </Style>
+  <Style Selector="local|RibbonWindow[WindowState=Maximized] /template/ Grid#ResizeGrid">
+    <Setter Property="IsVisible" Value="False"/>
+  </Style>
+  <Style Selector="local|RibbonWindow[HasSystemDecorations=True] /template/ Grid#ResizeGrid">
+    <Setter Property="IsVisible" Value="False"/>
+  </Style>
+  <Style Selector="local|RibbonWindow[IsActive=false]">
+    <Setter Property="BorderBrush" Value="{DynamicResource InactiveTitleBarColorBrush}"/>
+    <Setter Property="TitleBarColor" Value="{DynamicResource InactiveTitleBarColorBrush}" />
+  </Style>
+  <Style Selector="local|RibbonWindow[IsActive=false] /template/ Grid#TitleBar > TextBlock">
+    <Setter Property="Opacity" Value="0.5"/>
+  </Style>
 </Styles>


### PR DESCRIPTION
- `RibbonControl` is now just `Ribbon`
- `RibbonTabGroup`s now use Items instead of Content, meaning no more boilerplate panels in each one - File menu is less ugly now: ![ Image of less-ugly File menu](https://i.imgur.com/EyaVI76.png)
- `RibbonWindow` is now an actual window
- Raster icons are no longer used, except by the buttons in the sample program, they're all vector now
- Switching tabs via scroll wheel no longer wraps around after reaching either end of the tab strip
- Probably something else I've forgotten about
